### PR TITLE
don't pollute container env

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zitadel
 description: A Helm chart for ZITADEL v2
 type: application
-version: 2.1.0
+version: 2.1.2
 appVersion: "v2.0.0-v2-alpha.23-amd64"
 kubeVersion: '>= 1.16.15 < 1.25.0'
 icon: https://zitadel.zitadel.cloud/ui/login/resources/themes/zitadel/logo-dark.svg

--- a/charts/zitadel/templates/deployment.yaml
+++ b/charts/zitadel/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       serviceAccountName: {{ include "zitadel.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      enableServiceLinks: false
       containers:
         - name: {{ .Chart.Name }}
           securityContext:


### PR DESCRIPTION
Fixes zitadel from releases named *zitadel* listening on a random port, because Kubernetes sets the ZITADEL_PORT environment variable.