### PR TITLE
Fix broken serviceMonitor tlsConfig

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL v2
 type: application
 appVersion: "v2.0.0-amd64"
-version: 3.0.0
+version: 3.0.1
 kubeVersion: '>= 1.16.15-0'
 icon: https://zitadel.zitadel.cloud/ui/login/resources/themes/zitadel/logo-dark.svg
 dependencies:

--- a/charts/zitadel/templates/servicemonitor.yaml
+++ b/charts/zitadel/templates/servicemonitor.yaml
@@ -33,7 +33,8 @@ spec:
     scheme: {{ .Values.metrics.serviceMonitor.scheme }}
     {{- end }}
     {{- if .Values.metrics.serviceMonitor.tlsConfig }}
-    tlsConfig: {{ .Values.metrics.serviceMonitor.tlsConfig }}
+    tlsConfig:
+      {{- toYaml .Values.metrics.serviceMonitor.tlsConfig | nindent 6 }}
     {{- end }}
     {{- if .Values.metrics.serviceMonitor.proxyUrl }}
     proxyUrl: {{ .Values.metrics.serviceMonitor.proxyUrl }}


### PR DESCRIPTION
The tlsConfig field for the ServiceMonitor object is a Map. Therefore we need to handle it as a map. 