### PR TITLE
fix(deployment): fix probes for external domain

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL v2
 type: application
 appVersion: "v2.2.0"
-version: 3.2.0
+version: 3.2.1
 kubeVersion: '>= 1.16.15-0'
 icon: https://zitadel.zitadel.cloud/ui/login/resources/themes/zitadel/logo-dark.svg
 dependencies:

--- a/charts/zitadel/templates/deployment.yaml
+++ b/charts/zitadel/templates/deployment.yaml
@@ -77,12 +77,22 @@ spec:
             httpGet:
               path: /debug/healthz
               port: {{ .Values.service.protocol }}-server
+              {{- if .Values.zitadel.configmapConfig.ExternalDomain }}
+              httpHeaders:
+                - name: Host
+                  value: {{ .Values.zitadel.configmapConfig.ExternalDomain }}
+              {{- end }}
             initialDelaySeconds: 60
             periodSeconds: 5
           readinessProbe:
             httpGet:
               path: /debug/ready
               port: {{ .Values.service.protocol }}-server
+              {{- if .Values.zitadel.configmapConfig.ExternalDomain }}
+              httpHeaders:
+                - name: Host
+                  value: {{ .Values.zitadel.configmapConfig.ExternalDomain }}
+              {{- end }}
             initialDelaySeconds: 60
             periodSeconds: 5
           volumeMounts:


### PR DESCRIPTION
Hello, team

With the config like this, my pods couldn't serve traffic and enter a crash loop due to failure of livenessProbe

```yaml
zitadel:
  masterkey: MX#dqpSDAF%ge7i#rG&y8vH$fEc5s**7

  configmapConfig:
    TLS:
      Enabled: false

    ExternalSecure: true
    ExternalDomain: zitadel.mydomain.io
    ExternalPort: 443

    Database:
      cockroach:
        User:
          Mode: 'verify-full'
          RootCert: "/.secrets/ca.crt"
          Cert: "/.secrets/tls.crt"
          Key: "/.secrets/tls.key"
        Admin:
          Mode: 'verify-full'
          RootCert: "/.secrets/ca.crt"
          Cert: "/.secrets/tls.crt"
          Key: "/.secrets/tls.key"
    DefaultInstance:
      DefaultLanguage: en
      Org:
        Name: 'Internal Users'
        Human:
          Username: 'root'
          Password: 'RootPassword1!'

  # https://github.com/zitadel/zitadel/blob/main/cmd/defaults.yaml
  secretConfig:
    Database:
      cockroach:
        User:
          Password: a-zitadel-db-user-password
        Admin:
          Password: a-zitadel-db-root-password

replicaCount: 2

# Note: downstream chart cockroachdb
# ref: https://github.com/cockroachdb/helm-charts/blob/77733911db972984ed9101266c1438d0e37a4f4b/cockroachdb/values.yaml
cockroachdb:
  tls:
    enabled: true
  conf:
    single-node: true
  statefulset:
    replicas: 1
  storage:
    persistentVolume:
      size: 20Gi
      storageClass: ebs-gp3-ext4-eu-west-1b
```
