### PR TITLE
Add option to configure additional env variables

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL v2
 type: application
 appVersion: "v2.2.0"
-version: 3.2.1
+version: 3.3.0
 kubeVersion: '>= 1.16.15-0'
 icon: https://zitadel.zitadel.cloud/ui/login/resources/themes/zitadel/logo-dark.svg
 dependencies:

--- a/charts/zitadel/templates/deployment.yaml
+++ b/charts/zitadel/templates/deployment.yaml
@@ -69,6 +69,9 @@ spec:
             - name: ZITADEL_DATABASE_COCKROACH_ADMIN_SSL_KEY
               value: /.secrets/tls.key
             {{- end}}
+            {{- with .Values.env }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
           - containerPort: 8080
             name: {{ .Values.service.protocol }}-server

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -82,6 +82,14 @@ podSecurityContext:
 
 securityContext: {}
 
+# Additional environment variables
+env: []
+  # - name: ZITADEL_DATABASE_POSTGRES_HOST
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: postgres-pguser-postgres
+  #       key: host
+
 service:
   type: ClusterIP
   port: 8080


### PR DESCRIPTION
I would like to use existing secrets to configure the deployment (e.g.: Postgres parameters)
For example when using crunchydata pgo the provisioned database and user parameters are generated into a secret. With this change this can be referenced instead of copying the parameters to a new zitadel secret.