### PR TITLE
feat: allow configuring readinessProbe, livenessProbe and add a startupProbe

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL v2
 type: application
 appVersion: "v2.13.1"
-version: 3.4.0
+version: 3.5.0
 kubeVersion: '>= 1.16.15-0'
 icon: https://zitadel.zitadel.cloud/ui/login/resources/themes/zitadel/logo-dark.svg
 dependencies:

--- a/charts/zitadel/templates/deployment.yaml
+++ b/charts/zitadel/templates/deployment.yaml
@@ -86,9 +86,9 @@ spec:
                 - name: Host
                   value: {{ .Values.zitadel.configmapConfig.ExternalDomain }}
               {{- end }}
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds | default 60 }}
-            periodSeconds: {{ .Values.livenessProbe.periodSeconds | default 5 }}
-            failureThreshold: {{ .Values.livenessProbe.failureThreshold | default 3 }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
@@ -100,9 +100,9 @@ spec:
                 - name: Host
                   value: {{ .Values.zitadel.configmapConfig.ExternalDomain }}
               {{- end }}
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds | default 60 }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds | default 5 }}
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold | default 3 }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           {{- end }}
           {{- if .Values.startupProbe.enabled }}
           startupProbe:
@@ -114,8 +114,8 @@ spec:
                 - name: Host
                   value: {{ .Values.zitadel.configmapConfig.ExternalDomain }}
               {{- end }}
-            periodSeconds: {{ .Values.startupProbe.periodSeconds | default 10 }}
-            failureThreshold: {{ .Values.startupProbe.failureThreshold | default 30 }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
           {{- end }}
           volumeMounts:
           - name: zitadel-config-yaml

--- a/charts/zitadel/templates/deployment.yaml
+++ b/charts/zitadel/templates/deployment.yaml
@@ -76,6 +76,7 @@ spec:
           - containerPort: 8080
             name: {{ .Values.service.protocol }}-server
             protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /debug/healthz
@@ -85,8 +86,11 @@ spec:
                 - name: Host
                   value: {{ .Values.zitadel.configmapConfig.ExternalDomain }}
               {{- end }}
-            initialDelaySeconds: 60
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds | default 60 }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds | default 5 }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold | default 3 }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /debug/ready
@@ -96,8 +100,23 @@ spec:
                 - name: Host
                   value: {{ .Values.zitadel.configmapConfig.ExternalDomain }}
               {{- end }}
-            initialDelaySeconds: 60
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds | default 60 }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds | default 5 }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold | default 3 }}
+          {{- end }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /debug/ready
+              port: {{ .Values.service.protocol }}-server
+              {{- if .Values.zitadel.configmapConfig.ExternalDomain }}
+              httpHeaders:
+                - name: Host
+                  value: {{ .Values.zitadel.configmapConfig.ExternalDomain }}
+              {{- end }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds | default 10 }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold | default 30 }}
+          {{- end }}
           volumeMounts:
           - name: zitadel-config-yaml
             mountPath: /config

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -115,6 +115,15 @@ tolerations: []
 
 affinity: {}
 
+readinessProbe:
+  enabled: true
+
+livenessProbe:
+  enabled: true
+
+startupProbe:
+  enabled: true
+
 metrics:
   enabled: false
   serviceMonitor:

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -117,12 +117,20 @@ affinity: {}
 
 readinessProbe:
   enabled: true
+  initialDelaySeconds: 60
+  periodSeconds: 5
+  failureThreshold: 3
 
 livenessProbe:
   enabled: true
+  initialDelaySeconds: 60
+  periodSeconds: 5
+  failureThreshold: 3
 
 startupProbe:
   enabled: true
+  periodSeconds: 10
+  failureThreshold: 30
 
 metrics:
   enabled: false


### PR DESCRIPTION
Make it possible to configure readinessProbe, livenessProbe and the startupProbe for the deployment. By default all 3 probes are enabled and only require the minimal configuration because it automatically sets accurate default values.

**Default values:**
```yaml
readinessProbe:
  initialDelaySeconds: 60
  periodSeconds: 5
  failureThreshold: 3

livenessProbe:
  initialDelaySeconds: 60
  periodSeconds: 5
  failureThreshold: 3

startupProbe:
  periodSeconds: 10
  failureThreshold: 30
```

The startupProbe allows the pods to live longer before the first liveness check happens at first startup to make sure migrations properly run through. The startup time, before the first liveness check happens, is calculated by `failureThreshold * periodSeconds` and therefore by default waits 300s (5 minutes) before the first check.

**Minimal configuration:**
```yaml
readinessProbe:
  enabled: true

livenessProbe:
  enabled: true

startupProbe:
  enabled: true
```

**Full configuration:**
```yaml
readinessProbe:
  enabled: true
  initialDelaySeconds: 30
  periodSeconds: 10
  failureThreshold: 5

livenessProbe:
  enabled: true
  initialDelaySeconds: 30
  periodSeconds: 10
  failureThreshold: 5

startupProbe:
  enabled: true
  periodSeconds: 5
  failureThreshold: 60
```

It is also possible to completely **disable** the probes:
```yaml
readinessProbe:
  enabled: false

livenessProbe:
  enabled: false

startupProbe:
  enabled: false
```