### PR TITLE
fix(deployment): use secretName provided in values for volume 'db-ssl-root-crt'

### DIFF
--- a/charts/zitadel/templates/deployment.yaml
+++ b/charts/zitadel/templates/deployment.yaml
@@ -181,7 +181,7 @@ spec:
       {{- if .Values.zitadel.dbSslRootCrt }}
       - name: db-ssl-root-crt
         secret:
-          secretName: db-ssl-root-crt
+          secretName: {{ .Values.zitadel.dbSslRootCrt | default "db-ssl-root-crt" }}
       {{- end }}
       {{- if .Values.zitadel.dbSslRootCrtSecret }}
       - name: db-ssl-root-crt


### PR DESCRIPTION
This would fix a problem where the secret is not found when installing the helm chart with cockroachdb