### PR TITLE
fix: configurable key writer image

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL v2
 type: application
 appVersion: "v2.15.0"
-version: 4.1.0
+version: 4.1.1
 kubeVersion: ">= 1.18.20-0"
 icon: https://zitadel.zitadel.cloud/ui/login/resources/themes/zitadel/logo-dark.svg
 maintainers:

--- a/charts/zitadel/templates/_helpers.tpl
+++ b/charts/zitadel/templates/_helpers.tpl
@@ -82,7 +82,3 @@ Join copy commands
     {{- end -}}
 {{ print $cmd }}
 {{- end -}}
-
-{{- define "zitadel.kubernetesVersion" -}}
-{{- trimPrefix "v" .Capabilities.KubeVersion.Version }}
-{{- end }}

--- a/charts/zitadel/templates/setupjob.yaml
+++ b/charts/zitadel/templates/setupjob.yaml
@@ -87,7 +87,7 @@ spec:
             {{- toYaml .Values.setupJob.resources | nindent 14 }}
         {{- if and .Values.zitadel.configmapConfig.FirstInstance .Values.zitadel.configmapConfig.FirstInstance.Org .Values.zitadel.configmapConfig.FirstInstance.Org.Machine }}
         - name: "{{ .Chart.Name}}-machinekey"
-          image: alpine/k8s:{{ include "zitadel.kubernetesVersion" . }}
+          image: "{{ .Values.setupJob.machinekeyWriterImage.repository }}:{{ .Values.setupJob.machinekeyWriterImage.tag | default ( trimPrefix "v" .Capabilities.KubeVersion.Version ) }}"
           command: [ "sh","-c","until [ ! -z $(kubectl -n {{ .Release.Namespace }} get po ${POD_NAME} -o jsonpath=\"{.status.containerStatuses[?(@.name=='{{ .Chart.Name }}-setup')].state.terminated}\") ]; echo 'waiting for {{ .Chart.Name }}-setup container to terminate'; do sleep 5; done && echo '{{ .Chart.Name }}-setup container terminated' && if [ -f {{ .Values.zitadel.configmapConfig.FirstInstance.MachineKeyPath }} ]; then kubectl -n {{ .Release.Namespace }} create secret generic {{ .Values.zitadel.configmapConfig.FirstInstance.Org.Machine.Machine.Username }} --from-file={{ .Values.zitadel.configmapConfig.FirstInstance.Org.Machine.Machine.Username }}.json={{ .Values.zitadel.configmapConfig.FirstInstance.MachineKeyPath }}; fi;" ]
           env:
             - name: POD_NAME

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -21,19 +21,21 @@ zitadel:
         Webhook:
           Enabled: false
 
-## If you want to setup ZITADEL only with a service account
-#    FirstInstance:
-## path used for volume mounts and to write the secret
-#      MachineKeyPath: /machinekey/zitadel-admin-sa.json
-#      Org:
-#        Machine:
-#          Machine:
-## Creates a service account with the name zitadel-admin-sa,
-## which results in a secret 'zitadel-admin-sa' with a key 'zitadel-admin-sa.json'
-#            Username: zitadel-admin-sa
-#            Name: Admin
-#          MachineKey:
-#            Type: 1
+    ## If you want to setup ZITADEL with a service account
+    ## instead of a human admin user, comment the following
+    ## in by deleting each lines first hash and space
+    # FirstInstance:
+    #   # path used for volume mounts and to write the secret
+    #   MachineKeyPath: /machinekey/zitadel-admin-sa.json
+    #   Org:
+    #     Machine:
+    #       Machine:
+    #         # Creates a service account with the name zitadel-admin-sa,
+    #         # which results in a secret 'zitadel-admin-sa' with a key 'zitadel-admin-sa.json'
+    #         Username: zitadel-admin-sa
+    #         Name: Admin
+    #       MachineKey:
+    #         Type: 1
 
   # The ZITADEL config under secretConfig is written to a Kubernetes Secret
   # See all defaults here:
@@ -141,6 +143,10 @@ setupJob:
   activeDeadlineSeconds: 300
   extraContainers: []
   podAnnotations: {}
+  machinekeyWriterImage:
+    repository: alpine/k8s
+    tag: ""
+
 
 readinessProbe:
   enabled: true


### PR DESCRIPTION
- Makes the setup job key writer image repo and tag configurable. Defaults to the Helm Capabilities objects k8s version for the tag.
- Makes the outcommented FirstInstance config a bit clearer. 
- Removes a helper template that's used just once.