### PR TITLE
fix: enable empty secrets

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL v2
 type: application
 appVersion: "v2.15.0"
-version: 4.1.1
+version: 4.1.2
 kubeVersion: ">= 1.18.20-0"
 icon: https://zitadel.zitadel.cloud/ui/login/resources/themes/zitadel/logo-dark.svg
 maintainers:

--- a/charts/zitadel/templates/deployment.yaml
+++ b/charts/zitadel/templates/deployment.yaml
@@ -193,9 +193,6 @@ spec:
         secret:
           secretName: {{ .Values.zitadel.dbSslClientCrtSecret }}
       {{- end }}
-{{- if (or (and .Values.zitadel.masterkey .Values.zitadel.masterkeySecretName) (and (not .Values.zitadel.masterkey) (not .Values.zitadel.masterkeySecretName)) ) }}
-{{- fail "Eighter set .Values.zitadel.masterkey or .Values.zitadel.masterkeySecretName exclusively" }}
-{{- end }}
       - name: masterkey
         secret:
           secretName: {{ default "zitadel-masterkey" .Values.zitadel.masterkeySecretName }}

--- a/charts/zitadel/templates/initjob.yaml
+++ b/charts/zitadel/templates/initjob.yaml
@@ -81,7 +81,7 @@ spec:
         {{- if .Values.initJob.extraContainers }}
         {{- toYaml .Values.initJob.extraContainers | nindent 8 }}
         {{- end }}
-      {{- if or .Values.zitadel.secretConfig .Values.zitadel.dbSslRootCrt .Values.zitadel.dbSslRootCrtSecret .Values.zitadel.dbSslClientCrtSecret .Values.zitadel.configSecretName -}}
+      {{- if or .Values.zitadel.secretConfig .Values.zitadel.dbSslRootCrt .Values.zitadel.dbSslRootCrtSecret .Values.zitadel.dbSslClientCrtSecret .Values.zitadel.configSecretName }}
       initContainers:
         - args:
           - "{{ include "zitadel.joincpcommands" (dict "commands" (list

--- a/charts/zitadel/templates/initjob.yaml
+++ b/charts/zitadel/templates/initjob.yaml
@@ -81,6 +81,7 @@ spec:
         {{- if .Values.initJob.extraContainers }}
         {{- toYaml .Values.initJob.extraContainers | nindent 8 }}
         {{- end }}
+      {{- if or .Values.zitadel.secretConfig .Values.zitadel.dbSslRootCrt .Values.zitadel.dbSslRootCrtSecret .Values.zitadel.dbSslClientCrtSecret .Values.zitadel.configSecretName -}}
       initContainers:
         - args:
           - "{{ include "zitadel.joincpcommands" (dict "commands" (list
@@ -117,6 +118,7 @@ spec:
           securityContext:
             runAsNonRoot: false
             runAsUser: 0
+      {{- end}}
       volumes:
       - name: zitadel-config-yaml
         configMap:
@@ -146,9 +148,6 @@ spec:
         secret:
           secretName: {{ .Values.zitadel.dbSslClientCrtSecret }}
       {{- end }}
-{{- if (or (and .Values.zitadel.masterkey .Values.zitadel.masterkeySecretName) (and (not .Values.zitadel.masterkey) (not .Values.zitadel.masterkeySecretName)) ) }}
-{{- fail "Eighter set .Values.zitadel.masterkey or .Values.zitadel.masterkeySecretName exclusively" }}
-{{- end }}
       - name: chowned-secrets
         emptyDir: {}
       {{- with .Values.nodeSelector }}

--- a/charts/zitadel/templates/secret_zitadel-masterkey.yaml
+++ b/charts/zitadel/templates/secret_zitadel-masterkey.yaml
@@ -1,3 +1,6 @@
+{{- if (or (and .Values.zitadel.masterkey .Values.zitadel.masterkeySecretName) (and (not .Values.zitadel.masterkey) (not .Values.zitadel.masterkeySecretName)) ) }}
+{{- fail "Eighter set .Values.zitadel.masterkey or .Values.zitadel.masterkeySecretName exclusively" }}
+{{- end }}
 {{- if .Values.zitadel.masterkey -}}
 apiVersion: v1
 kind: Secret

--- a/charts/zitadel/templates/setupjob.yaml
+++ b/charts/zitadel/templates/setupjob.yaml
@@ -174,9 +174,6 @@ spec:
       - name: machinekey
         emptyDir: { }
       {{- end }}
-{{- if (or (and .Values.zitadel.masterkey .Values.zitadel.masterkeySecretName) (and (not .Values.zitadel.masterkey) (not .Values.zitadel.masterkeySecretName)) ) }}
-{{- fail "Eighter set .Values.zitadel.masterkey or .Values.zitadel.masterkeySecretName exclusively" }}
-{{- end }}
       - name: masterkey
         secret:
           secretName: {{ default "zitadel-masterkey" .Values.zitadel.masterkeySecretName }}


### PR DESCRIPTION
closes #57 

The check if an init container is needed just has to be done for the init job. The setup job and the deployment always mount at least the masterkey secret.