### PR TITLE
fix: Only create secret if configuration is provided via `secretConfig`

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL v2
 type: application
 appVersion: "v2.15.0"
-version: 4.1.3
+version: 4.1.4
 kubeVersion: ">= 1.18.20-0"
 icon: https://zitadel.zitadel.cloud/ui/login/resources/themes/zitadel/logo-dark.svg
 maintainers:

--- a/charts/zitadel/templates/secret_zitadel-secrets.yaml
+++ b/charts/zitadel/templates/secret_zitadel-secrets.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.zitadel.secretConfig -}}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -12,3 +13,4 @@ metadata:
 stringData:
   zitadel-secrets-yaml: |-
     {{ .Values.zitadel.secretConfig | toYaml | nindent 4 }}
+{{- end -}}


### PR DESCRIPTION
Fixes #62 