### PR TITLE
docs: fix URL for Zitadel k8s deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ By default, this chart installs a highly available ZITADEL deployment.
 
 ## Install the Chart
 
-Follow the [guide for deploying ZITADEL on Kubernetes](https://docs.zitadel.com/guides/deploy/kubernetes).
+Follow the [guide for deploying ZITADEL on Kubernetes](https://zitadel.com/docs/self-hosting/deploy/kubernetes).
 
 ## Upgrading from v3
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ By default, this chart installs a highly available ZITADEL deployment.
 
 ## Install the Chart
 
-Follow the [guide for deploying ZITADEL on Kubernetes](https://docs.zitadel.com/docs/guides/deploy/kubernetes).
+Follow the [guide for deploying ZITADEL on Kubernetes](https://docs.zitadel.com/guides/deploy/kubernetes).
 
 ## Upgrading from v3
 


### PR DESCRIPTION
The current URL does not link to the docs; removing the /docs/ path fixes the URL.