### PR TITLE
Makes TLS Modes configurable

### DIFF
--- a/charts/zitadel/templates/deployment.yaml
+++ b/charts/zitadel/templates/deployment.yaml
@@ -51,6 +51,10 @@ spec:
             {{- end }}
             - --masterkeyFile
             - /.secrets/masterkey
+            {{- if .Values.zitadel.tlsMode }}
+            - --tlsMode
+            - {{ .Values.zitadel.tlsMode }}
+            {{- end }}
           env:
             - name: POD_IP
               valueFrom:

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -37,6 +37,8 @@ zitadel:
     #       MachineKey:
     #         Type: 1
 
+  tlsMode:
+
   # The ZITADEL config under secretConfig is written to a Kubernetes Secret
   # See all defaults here:
   # https://github.com/zitadel/zitadel/blob/main/cmd/defaults.yaml
@@ -149,19 +151,19 @@ setupJob:
 
 
 readinessProbe:
-  enabled: true
+  enabled: false
   initialDelaySeconds: 0
   periodSeconds: 5
   failureThreshold: 3
 
 livenessProbe:
-  enabled: true
+  enabled: false
   initialDelaySeconds: 0
   periodSeconds: 5
   failureThreshold: 3
 
 startupProbe:
-  enabled: true
+  enabled: false
   periodSeconds: 1
   failureThreshold: 30
 

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -151,19 +151,19 @@ setupJob:
 
 
 readinessProbe:
-  enabled: false
+  enabled: true
   initialDelaySeconds: 0
   periodSeconds: 5
   failureThreshold: 3
 
 livenessProbe:
-  enabled: false
+  enabled: true
   initialDelaySeconds: 0
   periodSeconds: 5
   failureThreshold: 3
 
 startupProbe:
-  enabled: false
+  enabled: true
   periodSeconds: 1
   failureThreshold: 30
 


### PR DESCRIPTION
This makes the TLS Modes configurable at Zitadel Container Startup, since the [documentation](https://zitadel.com/docs/self-hosting/manage/tls_modes) says, that you can set TLS-Mode to external, when you use an Reverse Proxy (Ingress Controller).