### PR TITLE
chore: add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+### Definition of Ready
+
+- [ ] Short description of the feature/issue is added in the pr description
+- [ ] PR is linked to the corresponding user story
+- [ ] Acceptance criteria are met
+- [ ] All open todos and follow ups are defined in a new ticket and justified
+- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
+- [ ] No debug or dead code
+- [ ] Documentation/examples are up-to-date
+- [ ] All non-functional requirements are met
+- [ ] If possible, [the test configuration](./charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,6 @@
 ### Definition of Ready
 
+- [ ] I am happy with the code
 - [ ] Short description of the feature/issue is added in the pr description
 - [ ] PR is linked to the corresponding user story
 - [ ] Acceptance criteria are met

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,7 @@
 - [ ] All open todos and follow ups are defined in a new ticket and justified
 - [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
 - [ ] No debug or dead code
+- [ ] My code has no repetitions
 - [ ] Documentation/examples are up-to-date
 - [ ] All non-functional requirements are met
 - [ ] If possible, [the test configuration](./charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes


### PR DESCRIPTION
Adds a PR template.

The ready for review check described in the linked issues AC *Acceptance tests ensure that installation works and ZITADEL becomes ready.* does not make much sense, as the automated tests ensure that anyways. The PR instead adds the ready for review check *If possible, [the test configuration](./charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes*.

It also copies some other ready for review checks that make sense from the ZITADEL repo.