### PR TITLE
feat: support helm 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,17 +7,27 @@ jobs:
 
     strategy:
       matrix:
-        # digests should be appended in image versions according to the KIND release notes
-        # https://github.com/kubernetes-sigs/kind/releases/tag/v0.14.0
-        kindest-image-tag:
-          - 'v1.18.20@sha256:738cdc23ed4be6cc0b7ea277a2ebcc454c8373d7d8fb991a7fcdbd126188e6d7'
-          - 'v1.19.16@sha256:a146f9819fece706b337d34125bbd5cb8ae4d25558427bf2fa3ee8ad231236f2'
-          - 'v1.20.15@sha256:45d0194a8069c46483a0e509088ab9249302af561ebee76a1281a1f08ecb4ed3'
-          - 'v1.21.14@sha256:ad5b7446dd8332439f22a1efdac73670f0da158c00f0a70b45716e7ef3fae20b'
-          - 'v1.22.15@sha256:bfd5eaae36849bfb3c1e3b9442f3da17d730718248939d9d547e86bbac5da586'
-          - 'v1.23.12@sha256:9402cf1330bbd3a0d097d2033fa489b2abe40d479cc5ef47d0b6a6960613148a'
-          - 'v1.24.6@sha256:97e8d00bc37a7598a0b32d1fabd155a96355c49fa0d4d4790aab0f161bf31be1'
-          - 'v1.25.2@sha256:9be91e9e9cdf116809841fc77ebdb8845443c4c72fe5218f3ae9eb57fdb4bace'
+        include:
+          # digests should be appended in image versions according to the KIND release notes
+          # https://github.com/kubernetes-sigs/kind/releases/tag/v0.14.0
+        - kindest-image-tag: 'v1.18.20@sha256:738cdc23ed4be6cc0b7ea277a2ebcc454c8373d7d8fb991a7fcdbd126188e6d7'
+          helm-version: v3.11.1
+        - kindest-image-tag: 'v1.19.16@sha256:a146f9819fece706b337d34125bbd5cb8ae4d25558427bf2fa3ee8ad231236f2'
+          helm-version: v3.11.1
+        - kindest-image-tag: 'v1.20.15@sha256:45d0194a8069c46483a0e509088ab9249302af561ebee76a1281a1f08ecb4ed3'
+          helm-version: v3.11.1
+        - kindest-image-tag: 'v1.21.14@sha256:ad5b7446dd8332439f22a1efdac73670f0da158c00f0a70b45716e7ef3fae20b'
+          helm-version: v3.11.1
+        - kindest-image-tag: 'v1.22.15@sha256:bfd5eaae36849bfb3c1e3b9442f3da17d730718248939d9d547e86bbac5da586'
+          helm-version: v3.11.1
+        - kindest-image-tag: 'v1.23.12@sha256:9402cf1330bbd3a0d097d2033fa489b2abe40d479cc5ef47d0b6a6960613148a'
+          helm-version: v3.11.1
+        - kindest-image-tag: 'v1.24.6@sha256:97e8d00bc37a7598a0b32d1fabd155a96355c49fa0d4d4790aab0f161bf31be1'
+          helm-version: v3.11.1
+        - kindest-image-tag: 'v1.25.2@sha256:9be91e9e9cdf116809841fc77ebdb8845443c4c72fe5218f3ae9eb57fdb4bace'
+          helm-version: v3.11.1
+        - kindest-image-tag: 'v1.25.2@sha256:9be91e9e9cdf116809841fc77ebdb8845443c4c72fe5218f3ae9eb57fdb4bace'
+          helm-version: v3.9.0
 
     runs-on: 'ubuntu-20.04'
 
@@ -34,7 +44,7 @@ jobs:
     - id: 'set-up-helm'
       uses: 'azure/setup-helm@v3.3'
       with:
-        version: 'v3.10.0'
+        version: '${{ matrix.helm-version }}'
 
     - id: 'set-up-python'
       uses: 'actions/setup-python@v2'

--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL v2
 type: application
 appVersion: "v2.23.1"
-version: 4.3.0
+version: 4.4.0
 kubeVersion: ">= 1.18.20-0"
 icon: https://zitadel.zitadel.cloud/ui/login/resources/themes/zitadel/logo-dark.svg
 maintainers:

--- a/charts/zitadel/templates/NOTES.txt
+++ b/charts/zitadel/templates/NOTES.txt
@@ -1,6 +1,6 @@
 Thank you for installing {{ .Chart.Name }}.
 
-{{- if and .Values.zitadel.configmapConfig.FirstInstance .Values.zitadel.configmapConfig.FirstInstance.Org .Values.zitadel.configmapConfig.FirstInstance.Org.Machine }}
+{{- if include "deepCheck" (dict "root" .Values "path" (splitList "." "zitadel.configmapConfig.FirstInstance.Org.Machine")) }}
 Extract your service account key for authenticating at the ZITADEL API's:
 
   $ kubectl -n {{ .Release.Namespace }} get secret {{ .Values.zitadel.configmapConfig.FirstInstance.Org.Machine.Machine.Username }} -o jsonpath='{ .data.{{ .Values.zitadel.configmapConfig.FirstInstance.Org.Machine.Machine.Username }}\.json }' | base64 -D

--- a/charts/zitadel/templates/_helpers.tpl
+++ b/charts/zitadel/templates/_helpers.tpl
@@ -82,3 +82,20 @@ Join copy commands
     {{- end -}}
 {{ print $cmd }}
 {{- end -}}
+
+{{/*
+Returns true if the full path is defined and the value at the end of the path is not empty
+*/}}
+{{- define "deepCheck" -}}
+  {{- if eq (len .path) 0 -}}
+    {{- if and .root (not (empty .root)) -}}
+      {{- true -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $head := index .path 0 -}}
+    {{- $tail := slice .path 1 (len .path) -}}
+    {{- if hasKey .root $head -}}
+      {{- include "deepCheck" (dict "root" (index .root $head) "path" $tail) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/zitadel/templates/rbac.yaml
+++ b/charts/zitadel/templates/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.zitadel.configmapConfig.FirstInstance .Values.zitadel.configmapConfig.FirstInstance.Org .Values.zitadel.configmapConfig.FirstInstance.Org.Machine }}
+{{- if include "deepCheck" (dict "root" .Values "path" (splitList "." "zitadel.configmapConfig.FirstInstance.Org.Machine")) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/zitadel/templates/setupjob.yaml
+++ b/charts/zitadel/templates/setupjob.yaml
@@ -79,16 +79,15 @@ spec:
             mountPath: /config
           - name: chowned-secrets
             mountPath: /.secrets
-          {{- if and .Values.zitadel.configmapConfig.FirstInstance .Values.zitadel.configmapConfig.FirstInstance.Org .Values.zitadel.configmapConfig.FirstInstance.Org.Machine }}
+          {{- if include "deepCheck" (dict "root" .Values "path" (splitList "." "zitadel.configmapConfig.FirstInstance.MachineKeyPath")) }}
           - name: machinekey
-            mountPath: {{ dir .Values.zitadel.configmapConfig.FirstInstance.MachineKeyPath }}
+            key: {{ .Values.zitadel.configmapConfig.FirstInstance.MachineKeyPath }}
           {{- end}}
           resources:
             {{- toYaml .Values.setupJob.resources | nindent 14 }}
-        {{- if and .Values.zitadel.configmapConfig.FirstInstance .Values.zitadel.configmapConfig.FirstInstance.Org .Values.zitadel.configmapConfig.FirstInstance.Org.Machine }}
+        {{- if include "deepCheck" (dict "root" .Values "path" (splitList "." "zitadel.configmapConfig.FirstInstance.Org.Machine")) }}
         - name: "{{ .Chart.Name}}-machinekey"
           image: "{{ .Values.setupJob.machinekeyWriterImage.repository }}:{{ .Values.setupJob.machinekeyWriterImage.tag | default ( trimPrefix "v" .Capabilities.KubeVersion.Version ) }}"
-          command: [ "sh","-c","until [ ! -z $(kubectl -n {{ .Release.Namespace }} get po ${POD_NAME} -o jsonpath=\"{.status.containerStatuses[?(@.name=='{{ .Chart.Name }}-setup')].state.terminated}\") ]; do echo 'waiting for {{ .Chart.Name }}-setup container to terminate'; sleep 5; done && echo '{{ .Chart.Name }}-setup container terminated' && if [ -f {{ .Values.zitadel.configmapConfig.FirstInstance.MachineKeyPath }} ]; then kubectl -n {{ .Release.Namespace }} create secret generic {{ .Values.zitadel.configmapConfig.FirstInstance.Org.Machine.Machine.Username }} --from-file={{ .Values.zitadel.configmapConfig.FirstInstance.Org.Machine.Machine.Username }}.json={{ .Values.zitadel.configmapConfig.FirstInstance.MachineKeyPath }}; fi;" ]
           env:
             - name: POD_NAME
               valueFrom:
@@ -96,7 +95,6 @@ spec:
                   fieldPath: metadata.name
           volumeMounts:
             - name: machinekey
-              mountPath: {{ dir .Values.zitadel.configmapConfig.FirstInstance.MachineKeyPath }}
        {{- end }}
         {{- if .Values.setupJob.extraContainers }}
         {{- toYaml .Values.setupJob.extraContainers | nindent 8 }}
@@ -170,7 +168,7 @@ spec:
         secret:
           secretName: {{ .Values.zitadel.dbSslClientCrtSecret }}
       {{- end }}
-      {{- if and .Values.zitadel.configmapConfig.FirstInstance .Values.zitadel.configmapConfig.FirstInstance.Org .Values.zitadel.configmapConfig.FirstInstance.Org.Machine }}
+      {{- if include "deepCheck" (dict "root" .Values "path" (splitList "." "zitadel.configmapConfig.FirstInstance.Org.Machine")) }}
       - name: machinekey
         emptyDir: { }
       {{- end }}


### PR DESCRIPTION
Templates in go 1.17 evaluated each argument to and/or, like for example:
```
{{- if and .Values.zitadel.configmapConfig.FirstInstance .Values.zitadel.configmapConfig.FirstInstance.Org .Values.zitadel.configmapConfig.FirstInstance.Org.Machine }}
```

This leads to nil pointers.

This PR adds
- a function to reliably check if a value is defined.
- a test in the pipeline that is executed with helm 3.9, which is compiled with go 1.17

The branch protection rule is already updated.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](./charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
