### PR TITLE
Add self-signed certificate init container

### DIFF
--- a/charts/zitadel/templates/deployment.yaml
+++ b/charts/zitadel/templates/deployment.yaml
@@ -122,6 +122,10 @@ spec:
             mountPath: /config
           - name: chowned-secrets
             mountPath: /.secrets
+          {{- if .Values.selfSignedCert.enabled }}
+          - name: tls
+            mountPath: /etc/tls
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 14 }}
       initContainers:
@@ -164,6 +168,39 @@ spec:
           securityContext:
             runAsNonRoot: false
             runAsUser: 0
+        {{- if .Values.selfSignedCert.enabled }}
+        - name: generate-self-signed-cert
+          image: alpine/openssl
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            {{- if .Values.selfSignedCert.additionalDnsName }}
+            - name: ADDITIONAL_DNS_NAME
+              value: {{ .Values.selfSignedCert.additionalDnsName }}
+            {{- end }}
+          volumeMounts:
+            - name: tls
+              mountPath: "/etc/tls"
+          command:
+            - "/bin/ash"
+            - "-c"
+            {{- if .Values.selfSignedCert.additionalDnsName }}
+            - "openssl req -nodes -x509 -sha256 -newkey rsa:4096 -keyout /etc/tls/tls.key -out /etc/tls/tls.crt -days 3560 -subj \"/CN=zitadel\" -addext \"subjectAltName = DNS:localhost,DNS:${POD_IP},DNS:${POD_NAME},DNS:${ADDITIONAL_DNS_NAME}\""
+            {{- else }}
+            - "openssl req -nodes -x509 -sha256 -newkey rsa:4096 -keyout /etc/tls/tls.key -out /etc/tls/tls.crt -days 3560 -subj \"/CN=zitadel\" -addext \"subjectAltName = DNS:localhost,DNS:${POD_IP},DNS:${POD_NAME}\""
+            {{- end }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            privileged: false
+            runAsUser: 1000
+        {{- end }}
       volumes:
       - name: zitadel-config-yaml
         configMap:
@@ -198,6 +235,10 @@ spec:
           secretName: {{ default "zitadel-masterkey" .Values.zitadel.masterkeySecretName }}
       - name: chowned-secrets
         emptyDir: {}
+      {{- if .Values.selfSignedCert.enabled }}
+      - name: tls
+        emptyDir: {}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -37,6 +37,14 @@ zitadel:
     #       MachineKey:
     #         Type: 1
 
+  # Generate a self-signed certificate using an init container
+  # This will also mount the generated files to /etc/tls/ so that you can reference them in the pod.
+  # By default, the SAN DNS names include, localhost, the POD IP address and the POD name. You may include one more by using additionalDnsName.
+  # E.G. KeyPath: /etc/tls/tls.key CertPath: /etc/tls/tls.crt
+  selfSignedCert:
+    enabled: false
+    additionalDnsName: my.zitadel.fqdn
+
   # The ZITADEL config under secretConfig is written to a Kubernetes Secret
   # See all defaults here:
   # https://github.com/zitadel/zitadel/blob/main/cmd/defaults.yaml

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -39,8 +39,8 @@ zitadel:
 
   # Generate a self-signed certificate using an init container
   # This will also mount the generated files to /etc/tls/ so that you can reference them in the pod.
-  # By default, the SAN DNS names include, localhost, the POD IP address and the POD name. You may include one more by using additionalDnsName.
   # E.G. KeyPath: /etc/tls/tls.key CertPath: /etc/tls/tls.crt
+  # By default, the SAN DNS names include, localhost, the POD IP address and the POD name. You may include one more by using additionalDnsName.
   selfSignedCert:
     enabled: false
     additionalDnsName: my.zitadel.fqdn


### PR DESCRIPTION
### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes

This PR adds the ability to enable an init container which will generate and store a self signed certificate for each pod that runs in the replica set.

The certificate is signed with the CN of "zitadel" and contains the following SAN's: localhost, Pod IP Address and Pod Name. Additionally, it can contain one more DNS name, specified in values, which will be added to the SAN.

By default, this is disabled in the values file, but if required can be enabled by setting selfSignedCert.enabled to true. You can add the DNS name you want to add the certificate in selfSignedCert.additionalDnsName. Omit this value if this is not required.

The init container uses a small alpine/openssl image to generate the certificate using the following command:

```
openssl req -nodes -x509 -sha256 -newkey rsa:4096 -keyout /etc/tls/tls.key -out /etc/tls/tls.crt -days 3560 -subj "/CN=zitadel" -addext "subjectAltName = DNS:localhost,DNS:${POD_IP},DNS:${POD_NAME}"
```

Enabling selfSignedCert also adds the correct volume and volumeMount for the /etc/tls directory. This is where the tls.crt and tls.key files will be stored. They can then be referenced in zitadel config directly. E.G. KeyPath: /etc/tls/tls.key CertPath: /etc/tls/tls.crt
