### PR TITLE
feat: Add Azure Helmfile PostgreSQL example

### DIFF
--- a/examples/21-postgres-pw-auth-azure/readme.md
+++ b/examples/21-postgres-pw-auth-azure/readme.md
@@ -1,0 +1,14 @@
+This example uses [`helmfile`](https://helmfile.readthedocs.io/) with [`helm-secrets`](https://github.com/jkroepke/helm-secrets) in combination with our [Kubernetes Deploy Guides](https://zitadel.com/docs/self-hosting/deploy/kubernetes) and the [PostgreSQL Database](https://zitadel.com/docs/self-hosting/manage/database#postgres) to provision a production-eligible ZITADEL instance. You can make this example work without `helmfile` by mirroring the `zitadel` configration to your declarative setup.
+
+The secrets are safely retrieved from Azure KeyVault in this example but you can also use other secret stores supported by `helm-secrets` or provide the secrets directly within the `values`.
+
+> **Warning**
+> Even though this examples strives to be complete, make sure to read our [Production Guide](https://zitadel.com/docs/self-hosting/manage/production) before you decide to use it as reference.
+
+You can provision the example via a `helmfile` command like this:
+
+```bash
+helmfile -f zitadel.yaml diff
+helmfile -f zitadel.yaml apply
+helmfile -f zitadel.yaml destroy
+```

--- a/examples/21-postgres-pw-auth-azure/zitadel.yaml
+++ b/examples/21-postgres-pw-auth-azure/zitadel.yaml
@@ -1,0 +1,69 @@
+repositories:
+  - name: zitadel
+    url: https://charts.zitadel.com
+
+environments:
+  default:
+    values:
+      - zitadel:
+        hostName: id.your-domain.tld
+        mainKey: ref+azurekeyvault://vault-name/zitadel-main-key
+        database:
+          host: ref+azurekeyvault://vault-name/host
+          port: ref+azurekeyvault://vault-name/port
+          username: ref+azurekeyvault://vault-name/username
+          password: ref+azurekeyvault://vault-name/password
+          zitadelPassword: ref+azurekeyvault://vault-name/zitadel-zitadel-password
+
+releases:
+  - name: zitadel
+    chart: zitadel/zitadel
+    namespace: iam
+    version: 5.0.0
+    createNamespace: true
+    wait: false
+    values:
+      - zitadel:
+          # The certificate is public in this case so you can store it in VCS; if not you should source it from secrets as well
+          dbSslRootCrt: |
+            -----BEGIN CERTIFICATE-----
+            MIIDrzCCAp[OMITTED FOR BREVITY]Mbp1ZWVbd4=
+            -----END CERTIFICATE-----
+          dbSslRootCrtSecret: null
+          dbSslClientCrtSecret: null
+          masterkey: {{ .Values.zitadel.mainKey | fetchSecretValue | quote }}
+          configmapConfig:
+            ExternalDomain: {{ .Values.zitadel.hostName }}
+            ExternalPort: 443
+            ExternalSecure: true
+            LogStore:
+              Access:
+                Stdout:
+                  Enabled: true
+            TLS:
+              Enabled: false # The example delegates this to the upstream ingress controller
+            Database:
+              postgres:
+                Host: {{ .Values.zitadel.database.host | fetchSecretValue | quote }}
+                Port: {{ .Values.zitadel.database.port | fetchSecretValue | quote }}
+                Database: zitadel
+                MaxOpenConns: 50
+                MaxConnLifetime: 1h
+                MaxConnIdleTime: 5m
+                Options:
+                User:
+                  Username: z1t4d3l # A bit more tricky to guess but could also use a secret
+                  Password: {{ .Values.zitadel.database.zitadelPassword | fetchSecretValue | quote }}
+                  SSL:
+                    Mode: verify-full
+                    RootCert: /.secrets/ca.crt
+                    Cert:
+                    Key:
+                Admin:
+                  Username: {{ .Values.zitadel.database.username | fetchSecretValue | quote }}
+                  Password: {{ .Values.zitadel.database.password | fetchSecretValue | quote }}
+                  SSL:
+                    Mode: verify-full
+                    RootCert: /.secrets/ca.crt
+                    Cert:
+                    Key:


### PR DESCRIPTION
Adds example that uses

- helmfile
- helm-secrets
- Azure KeyVault
- PostgreSQL

Refs: https://github.com/zitadel/zitadel/pull/6283

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes

