### PR TITLE
Update release.yml - auto-generate release notes on chart release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,4 +32,4 @@ jobs:
       uses: 'helm/chart-releaser-action@v1.4.1'
       env:
         CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
+        CR_GENERATE_RELEASE_NOTES: true

--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zitadel
-description: A Helm chart for ZITADEL v2
+description: A Helm chart for ZITADEL
 type: application
 appVersion: "v2.28.1"
 version: 5.0.0

--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zitadel
-description: A Helm chart for ZITADEL
+description: A Helm chart for ZITADEL v2
 type: application
 appVersion: "v2.28.1"
 version: 5.0.0


### PR DESCRIPTION
This uses [GitHub's automated release notes](https://docs.github.com/en/rest/releases/releases) generator to grab any PR merged between releases of the helm chart. It will also generate a link for all changes between releases (including those not in PRs). It works by passing in ` --generate-release-notes` to `cr`. You can read more [here](https://github.com/helm/chart-releaser#create-github-releases-from-helm-chart-packages).

We may also want to update to the latest verison of the chart releaser action (`v1.5.0`):
https://github.com/helm/chart-releaser-action/releases

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [x] My code has no repetitions
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
