### PR TITLE
Add support for define `topologySpreadConstraints`

### DIFF
--- a/charts/zitadel/templates/deployment.yaml
+++ b/charts/zitadel/templates/deployment.yaml
@@ -206,3 +206,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -110,6 +110,8 @@ tolerations: []
 
 affinity: {}
 
+topologySpreadConstraints: []
+
 initJob:
   # Once ZITADEL is installed, the initJob can be disabled.
   enabled: true


### PR DESCRIPTION
### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes

This PR add support for k8s `topologySpreadConstraints ` - https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/

https://github.com/zitadel/zitadel-charts/issues/135