### PR TITLE
Make the initJob's backoff limit configurable via values.yaml

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: "v2.41.1"
-version: 7.3.0
+version: 7.3.1
 kubeVersion: ">= 1.21.0-0"
 icon: https://zitadel.com/zitadel-logo-dark.svg
 maintainers:

--- a/charts/zitadel/templates/initjob.yaml
+++ b/charts/zitadel/templates/initjob.yaml
@@ -11,7 +11,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  backoffLimit: 5
+  backoffLimit: {{ .Values.initJob.backoffLimit }}
   activeDeadlineSeconds: {{ .Values.initJob.activeDeadlineSeconds }}
   template:
     metadata:

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -129,6 +129,7 @@ initJob:
     helm.sh/hook-delete-policy: before-hook-creation
     helm.sh/hook-weight: "1"
   resources: {}
+  backoffLimit: 5
   activeDeadlineSeconds: 300
   extraContainers: []
   podAnnotations: {}


### PR DESCRIPTION
### Definition of Ready

This makes the initJob's backoffLimit configurable, so that it will restart as much as needed while waiting for mounted database TLS secrets to become available. This helps when databases are slower to provision than zitadel expects if you're deploying both at the same time.

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
