### PR TITLE
chore: Test against Kubernetes 1.28

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,12 +31,14 @@ jobs:
           kindest-image-tag: 'v1.26.6@sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb'
         - version: v1.27
           kindest-image-tag: 'v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72'
+        - version: v1.28
+          kindest-image-tag: 'v1.28.0@sha256:9f3ff58f19dcf1a0611d11e8ac989fdb30a28f40f236f59f0bea31fb956ccf5c'
         helm-version:
         - latest
         include:
         - k8s:
-            version: v1.27
-            kindest-image-tag: 'v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72'
+            version: v1.28
+            kindest-image-tag: 'v1.28.0@sha256:9f3ff58f19dcf1a0611d11e8ac989fdb30a28f40f236f59f0bea31fb956ccf5c'
           helm-version: v3.9.0
 
     name: 'K8s version ${{ matrix.k8s.version }} - Helm version ${{ matrix.helm-version }}'


### PR DESCRIPTION
Since Kubernetes version 1.28 was released in August and is available for production use on various cloud providers, the chart should be tested against this version.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
