### PR TITLE
Add namespace to chart templates

### DIFF
--- a/charts/zitadel/templates/_helpers.tpl
+++ b/charts/zitadel/templates/_helpers.tpl
@@ -6,6 +6,18 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+Namespace for all resources to be installed into
+If not defined in values file then the helm release namespace is used
+By default this is not set so the helm release namespace will be used
+
+This gets around an problem within helm discussed here
+https://github.com/helm/helm/issues/5358
+*/}}
+{{- define "zitadel.namespace" -}}
+    {{ .Values.namespace | default .Release.Namespace }}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/charts/zitadel/templates/configmap.yaml
+++ b/charts/zitadel/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: zitadel-config-yaml
+  namespace: {{ include "zitadel.namespace" . }}
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation

--- a/charts/zitadel/templates/deployment.yaml
+++ b/charts/zitadel/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "zitadel.fullname" . }}
+  namespace: {{ include "zitadel.namespace" . }}
   labels:
     {{- include "zitadel.labels" . | nindent 4 }}
     app.kubernetes.io/component: start

--- a/charts/zitadel/templates/ingress.yaml
+++ b/charts/zitadel/templates/ingress.yaml
@@ -16,6 +16,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ include "zitadel.namespace" . }}
   labels:
     {{- include "zitadel.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/zitadel/templates/initjob.yaml
+++ b/charts/zitadel/templates/initjob.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: "{{ include "zitadel.fullname" . }}-init"
+  namespace: "zitadel"
   labels:
     {{- include "zitadel.labels" . | nindent 4 }}
     app.kubernetes.io/component: init

--- a/charts/zitadel/templates/pdb.yaml
+++ b/charts/zitadel/templates/pdb.yaml
@@ -7,6 +7,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "zitadel.fullname" . }}
+  namespace: {{ include "zitadel.namespace" . }}
   labels:
     {{- include "zitadel.labels" . | nindent 4 }}
   {{- with .Values.pdb.annotations }}

--- a/charts/zitadel/templates/rbac.yaml
+++ b/charts/zitadel/templates/rbac.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "zitadel.serviceAccountName" . }}
+  namespace: {{ include "zitadel.namespace" . }}
   labels:
     {{- include "zitadel.labels" . | nindent 4 }}
   annotations:

--- a/charts/zitadel/templates/secret_db-ssl-root-crt.yaml
+++ b/charts/zitadel/templates/secret_db-ssl-root-crt.yaml
@@ -4,6 +4,7 @@ kind: Secret
 type: Opaque
 metadata:
   name: db-ssl-root-crt
+  namespace: {{ include "zitadel.namespace" . }}
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation

--- a/charts/zitadel/templates/secret_zitadel-masterkey.yaml
+++ b/charts/zitadel/templates/secret_zitadel-masterkey.yaml
@@ -7,6 +7,7 @@ kind: Secret
 type: Opaque
 metadata:
   name: zitadel-masterkey
+  namespace: {{ include "zitadel.namespace" . }}
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation

--- a/charts/zitadel/templates/secret_zitadel-secrets.yaml
+++ b/charts/zitadel/templates/secret_zitadel-secrets.yaml
@@ -4,6 +4,7 @@ kind: Secret
 type: Opaque
 metadata:
   name: zitadel-secrets-yaml
+  namespace: {{ include "zitadel.namespace" . }}
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation

--- a/charts/zitadel/templates/service.yaml
+++ b/charts/zitadel/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "zitadel.fullname" . }}
+  namespace: {{ include "zitadel.namespace" . }}
   {{- if .Values.service }}
   {{- with .Values.service.annotations }}
   annotations:

--- a/charts/zitadel/templates/serviceaccount.yaml
+++ b/charts/zitadel/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "zitadel.serviceAccountName" . }}
+  namespace: {{ include "zitadel.namespace" . }}
   labels:
     {{- include "zitadel.labels" . | nindent 4 }}
   annotations:

--- a/charts/zitadel/templates/servicemonitor.yaml
+++ b/charts/zitadel/templates/servicemonitor.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "zitadel.fullname" . }}
   {{- if .Values.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ include "zitadel.namespace" . }}
   {{- end }}
   labels:
     {{- include "zitadel.labels" . | nindent 4 }}

--- a/charts/zitadel/templates/setupjob.yaml
+++ b/charts/zitadel/templates/setupjob.yaml
@@ -5,6 +5,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: "{{ include "zitadel.fullname" . }}-setup"
+  namespace: {{ include "zitadel.namespace" . }}
   labels:
     {{- include "zitadel.labels" . | nindent 4 }}
     app.kubernetes.io/component: setup

--- a/charts/zitadel/templates/tests/test-connection.yaml
+++ b/charts/zitadel/templates/tests/test-connection.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "zitadel.fullname" . }}-test-connection"
+  namespace: {{ include "zitadel.namespace" . }}
   labels:
     {{- include "zitadel.labels" . | nindent 4 }}
   annotations:


### PR DESCRIPTION
Hi, it seems that this helm chart does not specify the `namespace` field on the Kubernetes resources it creates, which prevents me from installing the chart in another namespace than `default.` I have added the namespace configuration in this PR. Let me know if there is anything else that needs to be adjusted.