### PR TITLE
feat: allow choose init command

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: "v2.41.1"
-version: 7.3.2
+version: 7.4.0
 kubeVersion: ">= 1.21.0-0"
 icon: https://zitadel.com/zitadel-logo-dark.svg
 maintainers:

--- a/charts/zitadel/templates/initjob.yaml
+++ b/charts/zitadel/templates/initjob.yaml
@@ -38,8 +38,16 @@ spec:
             {{- toYaml .Values.securityContext | nindent 14 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+
           args:
             - init
+            {{- with .Values.initJob.command }}
+            {{/* test if command is valid */}}
+            {{- if not (has . (list "database" "grant" "user" "zitadel")) }}
+            {{- fail "You can only set one of the following command: database, grant, user, zitadel" }}
+            {{- end -}}
+            - {{ . }}
+            {{- end }}
             - --config
             - /config/zitadel-config-yaml
             {{- if .Values.zitadel.secretConfig }}

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -133,6 +133,13 @@ initJob:
   activeDeadlineSeconds: 300
   extraContainers: []
   podAnnotations: {}
+  # Available init commands :
+  # "": initialize ZITADEL instance (without skip anything)
+  # database: initialize only the database
+  # grant: set ALL grant to user
+  # user: initialize only the database user
+  # zitadel: initialize ZITADEL internals (skip "create user" and "create database")
+  command: ""
 
 setupJob:
   annotations:


### PR DESCRIPTION
Hello,
This little PR add an `initJob.command` option to allow users specify witch command want on init job.
This is really useful when we don't want specify "admin" DB user and not running init step manually.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
