### PR TITLE
feat: add annotation fields to configMap and deployment resources

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: "v2.41.1"
-version: 7.4.0
+version: 7.5.0
 kubeVersion: ">= 1.21.0-0"
 icon: https://zitadel.com/zitadel-logo-dark.svg
 maintainers:

--- a/charts/zitadel/templates/configmap.yaml
+++ b/charts/zitadel/templates/configmap.yaml
@@ -6,6 +6,9 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation
     helm.sh/hook-weight: "0"
+    {{- with .Values.configMap.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "zitadel.labels" . | nindent 4 }}
 data:

--- a/charts/zitadel/templates/deployment.yaml
+++ b/charts/zitadel/templates/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     {{- include "zitadel.labels" . | nindent 4 }}
     app.kubernetes.io/component: start
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -66,6 +66,13 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# Annotations to add to the deployment
+annotations: {}
+
+# Annotations to add to the configMap
+configMap:
+  annotations: {}
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
### Description

Added the following annotation fields to support further customizability when using tooling that allows customization via annotations. #159

Stakater reloader & ArgoCD are examples of this, by allowing us to add annotations to these resources we can further control certain aspects of our environment.

This change is a pure addition to the code base and should not have any impact while upgrading.

### Definition of Ready

- [x] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
