### PR TITLE
feat: support multi-chart deployment

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: "v2.41.1"
-version: 7.5.0
+version: 7.6.0
 kubeVersion: ">= 1.21.0-0"
 icon: https://zitadel.com/zitadel-logo-dark.svg
 maintainers:

--- a/charts/zitadel/templates/configmap.yaml
+++ b/charts/zitadel/templates/configmap.yaml
@@ -2,13 +2,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: zitadel-config-yaml
+  {{- with .Values.configMap.annotations }}
   annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation
-    helm.sh/hook-weight: "0"
-    {{- with .Values.configMap.annotations }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "zitadel.labels" . | nindent 4 }}
 data:

--- a/charts/zitadel/templates/rbac.yaml
+++ b/charts/zitadel/templates/rbac.yaml
@@ -5,10 +5,10 @@ metadata:
   name: {{ include "zitadel.serviceAccountName" . }}
   labels:
     {{- include "zitadel.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
   annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation
-    helm.sh/hook-weight: "0"
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups: [ "" ]
     resources: [ "secrets" ]
@@ -23,10 +23,10 @@ metadata:
   name: {{ include "zitadel.serviceAccountName" . }}
   labels:
     {{- include "zitadel.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
   annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation
-    helm.sh/hook-weight: "0"
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 subjects:
   - kind: ServiceAccount
     name:  {{ include "zitadel.serviceAccountName" . }}

--- a/charts/zitadel/templates/secret_db-ssl-root-crt.yaml
+++ b/charts/zitadel/templates/secret_db-ssl-root-crt.yaml
@@ -5,9 +5,15 @@ type: Opaque
 metadata:
   name: db-ssl-root-crt
   annotations:
+  {{- if .Values.zitadel.dbSslRootCrtAnnotations }}
+    {{- with .Values.zitadel.dbSslRootCrtAnnotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- else }}
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation
     helm.sh/hook-weight: "0"
+  {{- end }}
   labels:
     {{- include "zitadel.labels" . | nindent 4 }}
 stringData:

--- a/charts/zitadel/templates/secret_zitadel-masterkey.yaml
+++ b/charts/zitadel/templates/secret_zitadel-masterkey.yaml
@@ -7,10 +7,11 @@ kind: Secret
 type: Opaque
 metadata:
   name: zitadel-masterkey
+  {{- with .Values.zitadel.masterkeyAnnotations }}
   annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation
-    helm.sh/hook-weight: "0"
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  annotations:
   labels:
     {{- include "zitadel.labels" . | nindent 4 }}
 stringData:

--- a/charts/zitadel/templates/secret_zitadel-masterkey.yaml
+++ b/charts/zitadel/templates/secret_zitadel-masterkey.yaml
@@ -11,7 +11,6 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  annotations:
   labels:
     {{- include "zitadel.labels" . | nindent 4 }}
 stringData:

--- a/charts/zitadel/templates/secret_zitadel-secrets.yaml
+++ b/charts/zitadel/templates/secret_zitadel-secrets.yaml
@@ -4,10 +4,10 @@ kind: Secret
 type: Opaque
 metadata:
   name: zitadel-secrets-yaml
+  {{- with .Values.zitadel.secretConfigAnnotations }}
   annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation
-    helm.sh/hook-weight: "0"
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "zitadel.labels" . | nindent 4 }}
 stringData:

--- a/charts/zitadel/templates/serviceaccount.yaml
+++ b/charts/zitadel/templates/serviceaccount.yaml
@@ -5,11 +5,8 @@ metadata:
   name: {{ include "zitadel.serviceAccountName" . }}
   labels:
     {{- include "zitadel.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
   annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation
-    helm.sh/hook-weight: "0"
-    {{- with .Values.serviceAccount.annotations }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -17,6 +17,12 @@ zitadel:
   # https://github.com/zitadel/zitadel/blob/main/cmd/defaults.yaml
   secretConfig:
 
+  # Annotations set on secretConfig secret
+  secretConfigAnnotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "0"
+
   # Reference the name of a secret that contains ZITADEL configuration.
   configSecretName:
   # The key under which the ZITADEL configuration is located in the secret.
@@ -28,6 +34,12 @@ zitadel:
   # Reference the name of the secret that contains the masterkey. The key should be named "masterkey".
   # Note: Either zitadel.masterkey or zitadel.masterkeySecretName must be set
   masterkeySecretName: ""
+
+  # Annotations set on masterkey secret
+  masterkeyAnnotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "0"
 
   # The CA Certificate needed for establishing secure database connections
   dbSslCaCrt: ""
@@ -71,13 +83,19 @@ annotations: {}
 
 # Annotations to add to the configMap
 configMap:
-  annotations: {}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "0"
 
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
   # Annotations to add to the service account
-  annotations: {}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "0"
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""


### PR DESCRIPTION
### Description

All information is referenced in https://github.com/zitadel/zitadel-charts/issues/161

As I would like to already incrementally fix this setup and ensure that Zitadel can easily be deployed the current proposal is to move these annotations:
```
helm.sh/hook: pre-install,pre-upgrade
helm.sh/hook-delete-policy: before-hook-creation
helm.sh/hook-weight: "1"
```
.. to the `values.yaml` as was basically already done for some resources already like the `initJob` [values.yaml#134](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/values.yaml#L134)

Goal for the initial PR is to make a non-breaking change on the chart

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [ ] My code has no repetitions
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes