### PR TITLE
chore: update pm board action

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -4,17 +4,39 @@ on:
   issues:
     types:
       - opened
+  pull_request_target:
+    types:
+      - opened
 
 jobs:
   add-to-project:
-    name: Add issue to project
+    name: Add issue and community pr to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.3.0
+      - name: add issue
+        uses: actions/add-to-project@v0.5.0
+        if: ${{ github.event_name == 'issues' }}
         with:
           # You can target a repository in a different organization
           # to the issue
           project-url: https://github.com/orgs/zitadel/projects/2
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-          labeled: OKR
-          label-operator: NOT
+      - uses: tspascoal/get-user-teams-membership@v3
+        id: checkUserMember
+        with:
+         username: ${{ github.actor }}
+         GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+      - name: add pr
+        uses: actions/add-to-project@v0.5.0
+        if: ${{ github.event_name == 'pull_request_target' && !contains(steps.checkUserMember.outputs.teams, 'engineers') && github.actor != 'app/dependabot'}}
+        with:
+          # You can target a repository in a different organization
+          # to the issue
+          project-url: https://github.com/orgs/zitadel/projects/2
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+      - uses: actions-ecosystem/action-add-labels@v1.1.0
+        if: ${{ github.event_name == 'pull_request_target' && !contains(steps.checkUserMember.outputs.teams, 'staff') && github.actor != 'app/dependabot'}}
+        with:
+          github_token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labels: |
+            os-contribution


### PR DESCRIPTION
automatically ad prs of non engineers to board and label community prs

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
