### PR TITLE
feat: add setupJob additionalArgs, default to `--init-projections=true`

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: "v2.41.1"
-version: 7.6.1
+version: 7.7.0
 kubeVersion: ">= 1.21.0-0"
 icon: https://zitadel.com/zitadel-logo-dark.svg
 maintainers:

--- a/charts/zitadel/templates/setupjob.yaml
+++ b/charts/zitadel/templates/setupjob.yaml
@@ -55,6 +55,9 @@ spec:
             - --steps
             - /config/zitadel-config-yaml
             - --masterkeyFromEnv
+            {{- if .Values.setupJob.additionalArgs }}
+            {{- toYaml .Values.setupJob.additionalArgs | nindent 12 }}
+            {{- end }}
           env:
             - name: POD_IP
               valueFrom:

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -175,6 +175,8 @@ setupJob:
   activeDeadlineSeconds: 300
   extraContainers: []
   podAnnotations: {}
+  additionalArgs:
+    - "--init-projections=true"
   machinekeyWriter:
     image:
       repository: bitnami/kubectl


### PR DESCRIPTION
Closes #168. This patch adds the ability to specify additional arguments to pass to the setup job besides the preconfigured ones. By default, `--init-projections=true` is passed. This ensures that the setup job properly migrates the database between versions.

### Definition of Ready

- [X] I am happy with the code
- [X] Short description of the feature/issue is added in the pr description
- [X] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
