### PR TITLE
feat: update appVersion to v2.54.2

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: "v2.54.1"
-version: 7.15.0
+version: 7.16.0
 kubeVersion: ">= 1.21.0-0"
 icon: https://zitadel.com/zitadel-logo-dark.svg
 maintainers:

--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zitadel
 description: A Helm chart for ZITADEL
 type: application
-appVersion: "v2.51.3"
+appVersion: "v2.54.1"
 version: 7.15.0
 kubeVersion: ">= 1.21.0-0"
 icon: https://zitadel.com/zitadel-logo-dark.svg

--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zitadel
 description: A Helm chart for ZITADEL
 type: application
-appVersion: "v2.54.1"
+appVersion: "v2.54.2"
 version: 7.16.0
 kubeVersion: ">= 1.21.0-0"
 icon: https://zitadel.com/zitadel-logo-dark.svg

--- a/charts/zitadel/acceptance/config.go
+++ b/charts/zitadel/acceptance/config.go
@@ -43,7 +43,7 @@ var (
 	Cockroach = databaseChart{
 		repoUrl: "https://charts.cockroachdb.com/",
 		name:    "cockroachdb",
-		version: "11.1.5",
+		version: "13.0.1",
 		testValues: map[string]string{
 			"statefulset.replicas": "1",
 			"conf.single-node":     "true",


### PR DESCRIPTION
### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes

**What is the current behavior?**
The previously implemented workflow functionality from PR zitadel/zitadel#4544, which automatically triggered a webhook post-ZITADEL release, has been removed. Consequently, the bump workflow (introduced in zitadel/zitadel-charts#43 and discussed in Issue #105) is no longer dispatched, as it depends on this mechanism. This issue is also tracked in the Product Management Backlog under item [30889015](https://github.com/orgs/zitadel/projects/2/views/1?filterQuery=Update+the+Chart+always+to+the+latest+stable&pane=issue&itemId=30889015).

**What is the new behavior?**
This PR updates the ZITADEL version to v2.54.1 manually.

> **What could be a permanent solution?** To resolve Issue #105 it may be necessary to reimplement the changes from PR [zitadel/zitadel#4544](https://github.com/zitadel/zitadel/pull/4544) in [Current ZITADEL Release Workflow](https://github.com/zitadel/zitadel/blob/6a1ec149d307881a07866008e6b9141f1518fac0/.github/workflows/release.yml).
> 
> ```yaml
>       - uses: tibdex/github-app-token@v1
>         id: generate-token
>         with:
>           app_id: ${{ secrets.APP_ID }}
>           private_key: ${{ secrets.APP_PRIVATE_KEY }}
>       - name: Bump Chart Version
>         uses: peter-evans/repository-dispatch@v2
>         if: steps.semantic.outputs.new_release_published == 'true' && github.ref == 'refs/heads/main'
>         with:
>           token: ${{ steps.generate-token.outputs.token }}
>           repository: zitadel/zitadel-charts
>           event-type: zitadel-released
>           client-payload: '{"semanticoutputs": "${{ steps.semantic.outputs }}"}'
> ```
> 
> However, the current bump workflow does not appear to be functional, as indicated by [![Bump Version](https://github.com/zitadel/zitadel-charts/actions/workflows/bump.yml/badge.svg)](https://github.com/zitadel/zitadel-charts/actions/workflows/bump.yml).
> 
> ![image](https://private-user-images.githubusercontent.com/26285351/326801112-0ee8a55c-ac11-4457-9f97-33aa1c1b3d47.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTc1OTAxNzYsIm5iZiI6MTcxNzU4OTg3NiwicGF0aCI6Ii8yNjI4NTM1MS8zMjY4MDExMTItMGVlOGE1NWMtYWMxMS00NDU3LTlmOTctMzNhYTFjMWIzZDQ3LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA2MDUlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNjA1VDEyMTc1NlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWFiODJhMjNlZTBjZjE4NWFkYTI5NWNiZmFlNDI3MzRmOWVkN2RjYjdhNGJlMGQ0NzlhZWMxOTE4N2QyZTEwNmUmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.pocg8ZEMgsl-g5MdJJuqYC3mJLgatoQk_ek5vxPI9yE)
> 
_Originally posted by @kleberbaum in https://github.com/zitadel/zitadel-charts/issues/198

**Your feedback and suggestions would be greatly appreciated.**

