### PR TITLE
test: add new error handling for user not found

### DIFF
--- a/charts/zitadel/acceptance/accessibility.go
+++ b/charts/zitadel/acceptance/accessibility.go
@@ -5,12 +5,13 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	mgmt_api "github.com/zitadel/zitadel-go/v2/pkg/client/zitadel/management"
 	"net/http"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	mgmt_api "github.com/zitadel/zitadel-go/v2/pkg/client/zitadel/management"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	corev1 "k8s.io/api/core/v1"
@@ -87,7 +88,9 @@ func (s *ConfigurationTest) checkAccessibility(pods []corev1.Pod) {
 			}
 			_, err = conn.Healthz(ctx, &mgmt_api.HealthzRequest{})
 			// TODO: Why is the key checked on the healthz RPC?
-			if strings.Contains(err.Error(), "Errors.AuthNKey.NotFound") || strings.Contains(err.Error(), "assertion invalid") {
+			if strings.Contains(err.Error(), "Errors.AuthNKey.NotFound") ||
+				strings.Contains(err.Error(), "Errors.User.NotFound") ||
+				strings.Contains(err.Error(), "assertion invalid") {
 				err = nil
 			}
 			return err


### PR DESCRIPTION
### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes

after v2.54.0 
`POST http://127.0.0.1.sslip.io:8080/oauth/v2/token` return Error.User.NotFound instead of assertion invalid

#210 