### PR TITLE
feat: upgrade default app version to v2.55.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,30 @@ Either follow the [guide for deploying ZITADEL on Kubernetes](https://zitadel.co
 - [Referenced Secrets Example](examples/5-referenced-secrets/README.md)
 - [Machine User Setup Example](examples/6-machine-user/README.md)
 
+## Upgrade from v7
+
+The default ZITADEL version is now >= v2.55.
+[This requires Cockroach DB to be at >= v23.2](https://zitadel.com/docs/support/advisory/a10009)
+If you are using an older version of Cockroach DB, please upgrade it before upgrading ZITADEL.
+
+Note that in order to upgrade cockroach, you should not jump minor versions.
+For example:
+
+```bash
+# install Cockroach DB v23.1.14
+helm upgrade db cockroachdb/cockroachdb --version 11.2.4 --reuse-values
+# install Cockroach DB v23.2.5
+helm upgrade db cockroachdb/cockroachdb --version 12.0.5 --reuse-values
+# install Cockroach DB v24.1.1
+helm upgrade db cockroachdb/cockroachdb --version 13.0.1 --reuse-values
+# install ZITADEL v2.55.0
+helm upgrade my-zitadel zitadel/zitadel --version 8.0.0 --reuse-values
+```
+
+Please refer to the docs by Cockroach Labs. The ZITADEL tests run against the [official CockroachDB chart](https://artifacthub.io/packages/helm/cockroachdb/cockroachdb).
+
+(Credits to @panapol-p and @kleberbaum :pray:)
+
 ## Upgrade from v6
 
 - Now, you have the flexibility to define resource requests and limits separately for the machineKeyWriter,

--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: zitadel
 description: A Helm chart for ZITADEL
 type: application
-appVersion: "v2.51.3"
-version: 7.15.0
+appVersion: "v2.55.0"
+version: 8.0.0
 kubeVersion: ">= 1.21.0-0"
 icon: https://zitadel.com/zitadel-logo-dark.svg
 maintainers:

--- a/charts/zitadel/acceptance/config.go
+++ b/charts/zitadel/acceptance/config.go
@@ -43,7 +43,7 @@ var (
 	Cockroach = databaseChart{
 		repoUrl: "https://charts.cockroachdb.com/",
 		name:    "cockroachdb",
-		version: "11.1.5",
+		version: "13.0.1",
 		testValues: map[string]string{
 			"statefulset.replicas": "1",
 			"conf.single-node":     "true",


### PR DESCRIPTION
# :warning: BREAKING CHANGE

The default ZITADEL version is now v2.55.0.
[This requires Cockroach DB to be at >= v23.2](https://zitadel.com/docs/support/advisory/a10009)
If you are using an older version of Cockroach DB, please upgrade it before upgrading ZITADEL.

Note that in order to upgrade cockroach, you should not jump minor versions.
For example:

```bash
# install Cockroach DB v23.1.14
helm upgrade db cockroachdb/cockroachdb --version 11.2.4 --reuse-values
# install Cockroach DB v23.2.5
helm upgrade db cockroachdb/cockroachdb --version 12.0.5 --reuse-values
# install Cockroach DB v24.1.1
helm upgrade db cockroachdb/cockroachdb --version 13.0.1 --reuse-values
# install ZITADEL v2.55.0
helm upgrade my-zitadel zitadel/zitadel --version 8.0.0 --reuse-values
```

Please refer to the docs by Cockroach Labs. The ZITADEL tests run against the [official CockroachDB chart](https://artifacthub.io/packages/helm/cockroachdb/cockroachdb).

(Credits to @panapol-p and @kleberbaum :pray:)

Replaces #210 

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
