### PR TITLE
chore: Dependabot updates for used Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,19 @@ updates:
     reviewers:
       - stebenz
       - eliobischof
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    commit-message:
+      prefix: "chore"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+        - "*"
+    reviewers:
+      - stebenz
+      - eliobischof
+


### PR DESCRIPTION
With this change, Dependabot will automatically be creating pull-requests for any shared actions or workflows used in Github Workflows.  

This means deprecations such as [this](https://github.com/zitadel/zitadel-charts/actions/runs/10008104661) will be a thing of the past fairly soon:
> The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/checkout@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

Hope you can use it!

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
