### PR TITLE
chore: fix bump workflow for manual runs

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -3,7 +3,12 @@ name: Bump Version
 on:
   repository_dispatch:
     types:
-    - zitadel-released
+    - zitadel-released 
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'ZITADEL Tag'
+        required: false
 
 permissions:
   contents: write
@@ -16,6 +21,44 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+    - name: Validate the manually given input tag, if any
+      if: ${{github.event_name == 'workflow_dispatch'}}
+      id: check-input
+      run: |
+        INPUT=${{github.event.inputs.tag}}
+        if ! [[ ${INPUT} =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+          echo "supplied invalid version number: ${INPUT}!"
+          echo "must be of schema: vX.X.X"
+          exit 1
+        fi
+        echo "::set-output name=input::${INPUT}"
+  
+    - name: Get Latest ZITADEL Release Version
+      id: latest-tag
+      uses: oprypin/find-latest-tag@v1
+      with:
+        repository: zitadel/zitadel
+        releases-only: true
+        # ignore prereleases
+        regex: '^v([0-9]+)\.([0-9]+)\.([0-9]+)$'
+
+    - name: Decide on Target ZITADEL Version
+      id: target-zitadel-version
+      run: |
+        INPUT=${{ steps.check-input.outputs.input }}
+        LATEST=${{ steps.latest-tag.outputs.tag }}
+        TARGET_ZITADEL_VERSION=${INPUT:-${LATEST}}
+        echo "input tag: ${INPUT}"
+        echo "latest tag: ${LATEST}"
+        echo "going to target zitadel version: ${TARGET_ZITADEL_VERSION}"
+        echo "::set-output name=tag::${TAG}"
+  
+    - name: Parse Target ZITADEL Version into Major, Minor, Patch
+      id: parsed-target-zitadel-version
+      uses: booxmedialtd/ws-action-parse-semver@v1
+      with:
+        input_string: ${{ steps.target-zitadel-version.outputs.tag }}
+
     - id: checkout
       uses: actions/checkout@v3
       with:
@@ -40,18 +83,18 @@ jobs:
         echo "Chart Version: ${{ steps.current-chart-version.outputs.data }}"
         echo "ZITADEL Version: ${{ steps.current-zitadel-version.outputs.data }}"
 
-    - name: Parse Last ZITADEL Version
+    - name: Parse Currently ZITADEL Version into Major, Minor, Patch
       id: parsed-last-zitadel-version
       uses: booxmedialtd/ws-action-parse-semver@v1
       with:
         input_string: ${{ steps.current-zitadel-version.outputs.data }}
 
-    - name: Set Version Type
+    - name: Set Version Update Type
       id: set-version-type
       run: |
-        [ ${{ github.event.client_payload.semanticoutputs.new_release_patch_version }} -gt ${{ steps.parsed-last-zitadel-version.outputs.patch }} ] && echo '::set-output name=type::PATCH' || true
-        [ ${{ github.event.client_payload.semanticoutputs.new_release_minor_version }} -gt ${{ steps.parsed-last-zitadel-version.outputs.minor }} ] && echo '::set-output name=type::MINOR' || true
-        [ ${{ github.event.client_payload.semanticoutputs.new_release_major_version }} -gt ${{ steps.parsed-last-zitadel-version.outputs.major }} ] && echo '::set-output name=type::MAJOR' || true
+        [ ${{ steps.parsed-target-zitadel-version.outputs.patch }} -gt ${{ steps.parsed-last-zitadel-version.outputs.patch }} ] && echo '::set-output name=type::PATCH' || true
+        [ ${{ steps.parsed-target-zitadel-version.outputs.minor }} -gt ${{ steps.parsed-last-zitadel-version.outputs.minor }} ] && echo '::set-output name=type::MINOR' || true
+        [ ${{ steps.parsed-target-zitadel-version.outputs.major }} -gt ${{ steps.parsed-last-zitadel-version.outputs.major }} ] && echo '::set-output name=type::MAJOR' || true
 
     - name: Bump Chart Version
       uses: jessicalostinspace/bump-semantic-version-action@v1.0.1
@@ -65,7 +108,7 @@ jobs:
       with:
         valueFile: 'charts/zitadel/Chart.yaml'
         propertyPath: 'appVersion'
-        value: ${{ github.event.client_payload.semanticoutputs.new_release_version }}
+        value: ${{ steps.target-zitadel-version.outputs.tag }}
         updateFile: true
         commitChange: false
         createPR: false


### PR DESCRIPTION
Invoke this workflow manually when you want to create an updated Helm chart. If you pass in a ZITADEL release tag, then that is the version the new chart will use, otherwise the chart will automatically refer to the latest version.

[Related chat thread](https://discord.com/channels/927474939156643850/1226884380262137937)

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
