### PR TITLE
chore: run checks on auto PRs

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -125,6 +125,13 @@ jobs:
     - name: Print Chart.yaml
       run: cat charts/zitadel/Chart.yaml
 
+    - name: Generate GitHub App Token
+      id: generate-token
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ secrets.ZITADEL_WORKFLOW_APP_ID }}
+        private-key: ${{ secrets.ZITADEL_WORKFLOW_APP_PRIVATE_KEY }}
+
     - name: Create Pull Request
       id: pull-request
       uses: peter-evans/create-pull-request@v6
@@ -132,6 +139,9 @@ jobs:
         title: Bump ZITADEL Version
         branch: create-pull-request/bump
         delete-branch: true
+        # We can't just use the GITHUB_TOKEN here, as it wouldn't trigger other workflows needed for the required checks.
+        # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
+        token: ${{ steps.generate-token.outputs.token }}
 
     - name: Enable Automerge
       if: steps.pull-request.outputs.pull-request-operation == 'created'


### PR DESCRIPTION
Checks for PRs created automatically using the GITHUB_TOKEN secret are pending forever. This prevents merging these PRs.
PRs created using a GitHub App token can trigger other workflows needed for their checks. 

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
