### PR TITLE
chore: sort tags

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -38,6 +38,7 @@ jobs:
       with:
         repository: zitadel/zitadel
         releases-only: true
+        sort-tags: true
         # ignore prereleases
         regex: '^v([0-9]+)\.([0-9]+)\.([0-9]+)$'
 


### PR DESCRIPTION
According to the action docs, sort-tags is disabled by default if releases-only is true.
https://github.com/oprypin/find-latest-tag?tab=readme-ov-file#inputs

Which is why the bump action can get wrong zitadel versions, like here: https://github.com/zitadel/zitadel-charts/pull/247

We explicitly enable sort-tags to fix this.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
