### PR TITLE
chore: trigger releases from auto PRs

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -148,7 +148,7 @@ jobs:
       if: steps.pull-request.outputs.pull-request-operation == 'created'
       run: gh pr merge --squash --auto "${{ steps.pull-request.outputs.pull-request-number }}"
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ steps.generate-token.outputs.token }}
 
     - name: Approve
       if: steps.pull-request.outputs.pull-request-operation == 'created'


### PR DESCRIPTION
GitHub workflows don't react on push events created with the GITHUB_TOKEN secret in order to avoid circular runs.
To bypass this, we have to create the events with the GitHub App token.
This ensures that the workflow .github/workflows/release.yml is triggered on auto PR merges.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
