### PR TITLE
fix: duplicate scheme in probes when TLS is enabled

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,8 +3,8 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: v2.61.0
-version: 8.4.0
-kubeVersion: '>= 1.21.0-0'
+version: 8.4.1
+kubeVersion: ">= 1.21.0-0"
 icon: https://zitadel.com/zitadel-logo-dark.svg
 maintainers:
   - name: zitadel

--- a/charts/zitadel/templates/deployment.yaml
+++ b/charts/zitadel/templates/deployment.yaml
@@ -103,7 +103,7 @@ spec:
             httpGet:
               path: /debug/healthz
               port: {{ .Values.service.protocol }}-server
-              scheme: {{ .Values.service.scheme }}
+
               {{- if .Values.zitadel.configmapConfig.ExternalDomain }}
               httpHeaders:
                 - name: Host
@@ -111,6 +111,8 @@ spec:
               {{- end }}
               {{- if include "deepCheck" (dict "root" .Values "path" (splitList "." "zitadel.configmapConfig.TLS.Enabled")) }}
               scheme: HTTPS
+              {{- else }}
+              scheme: {{ .Values.service.scheme }}
               {{- end }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -121,7 +123,6 @@ spec:
             httpGet:
               path: /debug/ready
               port: {{ .Values.service.protocol }}-server
-              scheme: {{ .Values.service.scheme }}
               {{- if .Values.zitadel.configmapConfig.ExternalDomain }}
               httpHeaders:
                 - name: Host
@@ -129,6 +130,8 @@ spec:
               {{- end }}
               {{- if include "deepCheck" (dict "root" .Values "path" (splitList "." "zitadel.configmapConfig.TLS.Enabled")) }}
               scheme: HTTPS
+              {{- else }}
+              scheme: {{ .Values.service.scheme }}
               {{- end }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
@@ -139,7 +142,6 @@ spec:
             httpGet:
               path: /debug/ready
               port: {{ .Values.service.protocol }}-server
-              scheme: {{ .Values.service.scheme }}
               {{- if .Values.zitadel.configmapConfig.ExternalDomain }}
               httpHeaders:
                 - name: Host
@@ -147,6 +149,8 @@ spec:
               {{- end }}
               {{- if include "deepCheck" (dict "root" .Values "path" (splitList "." "zitadel.configmapConfig.TLS.Enabled")) }}
               scheme: HTTPS
+              {{- else }}
+              scheme: {{ .Values.service.scheme }}
               {{- end }}
             periodSeconds: {{ .Values.startupProbe.periodSeconds }}
             failureThreshold: {{ .Values.startupProbe.failureThreshold }}


### PR DESCRIPTION
## Description
When TLS is enabled it produces a duplicate `scheme` for probes: one for HTTP and the other one for HTTPS
```yaml
        TLS:
          Enabled: true
          KeyPath: /tls/tls.key
          CertPath: /tls/tls.crt
 ```
