### PR TITLE
feat: sourcing envVars from a secret

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: v2.61.0
-version: 8.4.1
+version: 8.5.0
 kubeVersion: ">= 1.21.0-0"
 icon: https://zitadel.com/zitadel-logo-dark.svg
 maintainers:

--- a/charts/zitadel/templates/debug_replicaset.yaml
+++ b/charts/zitadel/templates/debug_replicaset.yaml
@@ -60,6 +60,11 @@ spec:
             {{- with .Values.env }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- if .Values.envVarsSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.envVarsSecret }}
+          {{- end }}
           volumeMounts:
           - name: zitadel-config-yaml
             mountPath: /config

--- a/charts/zitadel/templates/deployment.yaml
+++ b/charts/zitadel/templates/deployment.yaml
@@ -94,6 +94,11 @@ spec:
             {{- with .Values.env }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- if .Values.envVarsSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.envVarsSecret }}
+          {{- end }}
           ports:
           - containerPort: 8080
             name: {{ .Values.service.protocol }}-server

--- a/charts/zitadel/templates/initjob.yaml
+++ b/charts/zitadel/templates/initjob.yaml
@@ -88,6 +88,11 @@ spec:
             {{- with .Values.env }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- if .Values.envVarsSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.envVarsSecret }}
+          {{- end }}
           volumeMounts:
           - name: zitadel-config-yaml
             mountPath: /config

--- a/charts/zitadel/templates/setupjob.yaml
+++ b/charts/zitadel/templates/setupjob.yaml
@@ -92,6 +92,11 @@ spec:
             {{- with .Values.env }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- if .Values.envVarsSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.envVarsSecret }}
+          {{- end }}
           volumeMounts:
           - name: zitadel-config-yaml
             mountPath: /config

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -132,6 +132,11 @@ env:
   #       name: postgres-pguser-postgres
   #       key: host
 
+# Additional environment variables from the given secret name
+# Zitadel can be configured using environment variables from a secret.
+# Reference: https://zitadel.com/docs/self-hosting/manage/configure#configure-by-environment-variables
+envVarsSecret: ""
+
 service:
   type: ClusterIP
   # If service type is "ClusterIP", this can optionally be set to a fixed IP address.


### PR DESCRIPTION
Being able to configure Zitadel using environment variables just like it is mentioned [here](https://zitadel.com/docs/self-hosting/manage/configure#configure-by-environment-variables).

This is particularly useful when using external secrets operator for instance, we could retrieve the database/user credentials from there without having to put them into the Helm variables.

This is an alternative to defining each environment variable specifically in the Helm values too.

My work in progress: https://github.com/Smana/cloud-native-ref/pull/448
