### PR TITLE
test: use go 1.23

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
     - id: 'setup-go'
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22.3'
+        go-version: '1.23.3'
       if: steps.list-changed-test.outputs.any_changed == 'true'
 
     - id: 'test'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zitadel/zitadel-charts
 
-go 1.22.3
+go 1.23.3
 
 require (
 	github.com/gruntwork-io/terratest v0.47.2


### PR DESCRIPTION
Uses go v1.23 to run the testsuite.

Even though this code is not meant to be imported and therefore this change is IMO not necessary according to https://github.com/zitadel/zitadel/issues/8906 because it already uses a supported go version, it can't hurt to upgrade it anyway.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
