### PR TITLE
fix(appProtocol): ensure appProtocol can be valid without invalidating probes

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: v2.65.3
-version: 8.7.0
+version: 8.7.1
 kubeVersion: '>= 1.21.0-0'
 icon: https://zitadel.com/zitadel-logo-dark.svg
 maintainers:

--- a/charts/zitadel/templates/service.yaml
+++ b/charts/zitadel/templates/service.yaml
@@ -21,7 +21,7 @@ spec:
       protocol: TCP
       name: {{ regexReplaceAll "\\W+" .Values.service.protocol "-" }}-server
       {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-      appProtocol: {{ .Values.service.protocol }}
+      appProtocol: {{ .Values.service.appProtocol }}
       {{- end }}
   selector:
     {{- include "zitadel.selectorLabels" . | nindent 4 }}

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -143,6 +143,7 @@ service:
   clusterIP: ""
   port: 8080
   protocol: http2
+  appProtocol: kubernetes.io/h2c
   annotations: {}
   scheme: HTTP
 


### PR DESCRIPTION
The appProtocol and the named ports for probes are very different things. The PR that added this together was didn't consider the valid values for appProtocol and how these aren't valid names for ports.

As per the Kubernetes documentation, the appProtocol:

```
kubectl explain svc.spec.ports.appProtocol
KIND:       Service
VERSION:    v1

FIELD: appProtocol <string>

DESCRIPTION:
    The application protocol for this port. This is used as a hint for
    implementations to offer richer behavior for protocols that they understand.
    This field follows standard Kubernetes label syntax. Valid values are
    either:

    * Un-prefixed protocol names - reserved for IANA standard service names (as
    per RFC-6335 and https://www.iana.org/assignments/service-names).

    * Kubernetes-defined prefixed names:
      * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described
    in
    https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
      * 'kubernetes.io/ws'  - WebSocket over cleartext as described in
    https://www.rfc-editor.org/rfc/rfc6455
      * 'kubernetes.io/wss' - WebSocket over TLS as described in
    https://www.rfc-editor.org/rfc/rfc6455

    * Other protocols should use implementation-defined prefixed names such as
    mycompany.com/my-custom-protocol.
```

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
