### PR TITLE
feat: add possibility to set extra labels and externalTrafficPolicy for service template

### DIFF
--- a/charts/zitadel/templates/service.yaml
+++ b/charts/zitadel/templates/service.yaml
@@ -10,10 +10,16 @@ metadata:
   {{- end }}
   labels:
     {{- include "zitadel.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   {{- if and .Values.service.clusterIP (eq .Values.service.type "ClusterIP") }}
   clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
+  {{- if and .Values.service.externalTrafficPolicy (eq .Values.service.type "LoadBalancer") }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}
   ports:
     - port: {{ .Values.service.port }}

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -141,10 +141,13 @@ service:
   type: ClusterIP
   # If service type is "ClusterIP", this can optionally be set to a fixed IP address.
   clusterIP: ""
+  # If service type is "LoadBalancer", this can optionally be set to either "Cluster" or "Local"
+  externalTrafficPolicy: ""
   port: 8080
   protocol: http2
   appProtocol: kubernetes.io/h2c
   annotations: {}
+  labels: {}
   scheme: HTTP
 
 ingress:


### PR DESCRIPTION
In some environments it's necessary to set `externalTrafficPolicy: Local` for a `LoadBalancer` service to preserve the client source IP (so network policies actually work). Also it's useful to add extra labels to a service, for example to [select cilium LoadBalancer IP Pool](https://docs.cilium.io/en/stable/network/lb-ipam/#service-selectors)

### Deinition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
