### PR TITLE
feat: Add ability to specify initContainers

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: v2.67.2
-version: 8.11.4
+version: 8.12.0
 kubeVersion: '>= 1.21.0-0'
 icon: https://zitadel.com/zitadel-logo-dark.svg
 maintainers:

--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: v2.67.2
-version: 8.11.3
+version: 8.11.4
 kubeVersion: '>= 1.21.0-0'
 icon: https://zitadel.com/zitadel-logo-dark.svg
 maintainers:

--- a/charts/zitadel/templates/debug_replicaset.yaml
+++ b/charts/zitadel/templates/debug_replicaset.yaml
@@ -31,12 +31,14 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       enableServiceLinks: false
+      {{- if or .Values.zitadel.initContainers .Values.debug.initContainers }}
       initContainers:
-      {{- if .Values.zitadel.initContainers }}
-        {{- toYaml .Values.zitadel.initContainers | nindent 8 }}
+      {{- with .Values.zitadel.initContainers }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.zitadel.debug.initContainers }}
-        {{- toYaml .Values.zitadel.debug.initContainers | nindent 8 }}
+      {{- with .Values.zitadel.debug.initContainers }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       containers:
       {{- if .Values.zitadel.extraContainers }}

--- a/charts/zitadel/templates/debug_replicaset.yaml
+++ b/charts/zitadel/templates/debug_replicaset.yaml
@@ -31,6 +31,13 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       enableServiceLinks: false
+      initContainers:
+      {{- if .Values.zitadel.initContainers }}
+        {{- toYaml .Values.zitadel.initContainers | nindent 8 }}
+      {{- end }}
+      {{- if .Values.zitadel.debug.initContainers }}
+        {{- toYaml .Values.zitadel.debug.initContainers | nindent 8 }}
+      {{- end }}
       containers:
       {{- if .Values.zitadel.extraContainers }}
         {{- toYaml .Values.zitadel.extraContainers | nindent 8 }}

--- a/charts/zitadel/templates/deployment.yaml
+++ b/charts/zitadel/templates/deployment.yaml
@@ -204,8 +204,11 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 14 }}
-      {{- if .Values.zitadel.selfSignedCert.enabled }}
       initContainers:
+      {{- if .Values.zitadel.initContainers }}
+        {{- toYaml .Values.zitadel.initContainers | nindent 8 }}
+      {{- end }}
+      {{- if .Values.zitadel.selfSignedCert.enabled }}
         - name: generate-self-signed-cert
           image: alpine/openssl
           env:

--- a/charts/zitadel/templates/deployment.yaml
+++ b/charts/zitadel/templates/deployment.yaml
@@ -204,9 +204,10 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 14 }}
+      {{- if or .Values.zitadel.selfSignedCert.enabled .Values.zitadel.initContainers}}
       initContainers:
-      {{- if .Values.zitadel.initContainers }}
-        {{- toYaml .Values.zitadel.initContainers | nindent 8 }}
+      {{- with .Values.zitadel.initContainers }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.zitadel.selfSignedCert.enabled }}
         - name: generate-self-signed-cert
@@ -229,6 +230,7 @@ spec:
             - "openssl req -nodes -x509 -sha256 -newkey rsa:4096 -keyout /etc/tls/tls.key -out /etc/tls/tls.crt -days 3560 -subj \"/CN=ZITADEL Chart Demo\" -addext \"subjectAltName = DNS:localhost,DNS:${POD_IP},DNS:${POD_NAME}{{- if .Values.zitadel.configmapConfig.ExternalDomain -}},DNS:{{- .Values.zitadel.configmapConfig.ExternalDomain -}}{{- end -}}{{- if .Values.zitadel.selfSignedCert.additionalDnsName -}},DNS:{{- .Values.zitadel.selfSignedCert.additionalDnsName -}}{{- end -}}\""
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+      {{- end }}
       {{- end }}
       volumes:
       - name: zitadel-config-yaml

--- a/charts/zitadel/templates/initjob.yaml
+++ b/charts/zitadel/templates/initjob.yaml
@@ -35,6 +35,13 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       enableServiceLinks: false
       restartPolicy: OnFailure
+      initContainers:
+      {{- if .Values.zitadel.initContainers }}
+        {{- toYaml .Values.zitadel.initContainers | nindent 8 }}
+      {{- end }}
+      {{- if .Values.initJob.initContainers }}
+        {{- toYaml .Values.initJob.initContainers | nindent 8 }}
+      {{- end }}
       containers:
       {{- if .Values.zitadel.extraContainers }}
         {{- toYaml .Values.zitadel.extraContainers | nindent 8 }}

--- a/charts/zitadel/templates/initjob.yaml
+++ b/charts/zitadel/templates/initjob.yaml
@@ -35,12 +35,14 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       enableServiceLinks: false
       restartPolicy: OnFailure
+      {{- if or .Values.zitadel.initContainers .Values.initJob.initContainers }}
       initContainers:
-      {{- if .Values.zitadel.initContainers }}
-        {{- toYaml .Values.zitadel.initContainers | nindent 8 }}
+      {{- with .Values.zitadel.initContainers }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.initJob.initContainers }}
-        {{- toYaml .Values.initJob.initContainers | nindent 8 }}
+      {{- with .Values.initJob.initContainers }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       containers:
       {{- if .Values.zitadel.extraContainers }}

--- a/charts/zitadel/templates/setupjob.yaml
+++ b/charts/zitadel/templates/setupjob.yaml
@@ -37,12 +37,14 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       enableServiceLinks: false
       restartPolicy: OnFailure
+      {{- if or .Values.zitadel.initContainers .Values.setupJob.initContainers }}
       initContainers:
-      {{- if .Values.zitadel.initContainers }}
-        {{- toYaml .Values.zitadel.initContainers | nindent 8 }}
+      {{- with .Values.zitadel.initContainers }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.setupJob.initContainers }}
-        {{- toYaml .Values.setupJob.initContainers | nindent 8 }}
+      {{- with .Values.setupJob.initContainers }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       containers:
       {{- if .Values.zitadel.extraContainers }}

--- a/charts/zitadel/templates/setupjob.yaml
+++ b/charts/zitadel/templates/setupjob.yaml
@@ -37,6 +37,13 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       enableServiceLinks: false
       restartPolicy: OnFailure
+      initContainers:
+      {{- if .Values.zitadel.initContainers }}
+        {{- toYaml .Values.zitadel.initContainers | nindent 8 }}
+      {{- end }}
+      {{- if .Values.setupJob.initContainers }}
+        {{- toYaml .Values.setupJob.initContainers | nindent 8 }}
+      {{- end }}
       containers:
       {{- if .Values.zitadel.extraContainers }}
         {{- toYaml .Values.zitadel.extraContainers | nindent 8 }}

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -79,8 +79,12 @@ zitadel:
     annotations:
       helm.sh/hook: pre-install,pre-upgrade
       helm.sh/hook-weight: "1"
+    initContainers: []
     extraContainers: []
 
+  # initContainers allow you to add any init containers you wish to use globally.
+  # Additionally, they follow the same structure as extraContainers
+  initContainers: []
   # extraContainers allows you to add any sidecar containers you wish to use globally.
   # Currently this is the Zitadel Deployment, Setup Job**, Init Job** and debug_replicaset**  **If Enabled
   extraContainers: []
@@ -227,6 +231,7 @@ initJob:
   resources: {}
   backoffLimit: 5
   activeDeadlineSeconds: 300
+  initContainers: []
   extraContainers: []
   podAnnotations: {}
   podAdditionalLabels: {}
@@ -245,6 +250,7 @@ setupJob:
     helm.sh/hook-weight: "2"
   resources: {}
   activeDeadlineSeconds: 300
+  initContainers: []
   extraContainers: []
   podAnnotations: {}
   podAdditionalLabels: {}


### PR DESCRIPTION
### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes

This piggybacks off #287 and extends the functionality to initContainers. This is an essential enhancement if you want to use a [native Kubernetes Sidecar](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/) instead of an extra container. This allows Jobs to function as expected rather than hanging forever. The primary use case is deploying to Google's CloudSQL and allowing the init/setup jobs to work and exit properly.

