### PR TITLE
feat(setup): make backoffLimit configurable

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # Please set the version explicitly using the appVersion variable if you need a newer Zitadel version.
 # The upcoming version 9 will include the latest Zitadel version by default (Zitadel v3).
 appVersion: v2.67.2
-version: 8.12.2
+version: 8.13.0
 kubeVersion: '>= 1.21.0-0'
 icon: https://zitadel.com/zitadel-logo-dark.svg
 maintainers:

--- a/charts/zitadel/templates/setupjob.yaml
+++ b/charts/zitadel/templates/setupjob.yaml
@@ -13,7 +13,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  backoffLimit: 5
+  backoffLimit: {{ .Values.setupJob.backoffLimit }}
   activeDeadlineSeconds: {{ .Values.setupJob.activeDeadlineSeconds }}
   template:
     metadata:

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -249,6 +249,7 @@ setupJob:
     helm.sh/hook-delete-policy: before-hook-creation
     helm.sh/hook-weight: "2"
   resources: {}
+  backoffLimit: 5
   activeDeadlineSeconds: 300
   initContainers: []
   extraContainers: []


### PR DESCRIPTION
With this PR, we make the setup jobs backoff limit configurable like we did it for the init job already.

Closes #314 

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
