### PR TITLE
chore: add workflow dispatch again

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -4,6 +4,11 @@ on:
   repository_dispatch:
     types:
     - zitadel-released 
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'ZITADEL Tag'
+        required: false
 
 jobs:
   bump:


### PR DESCRIPTION
The [wrong trigger was removed](https://github.com/zitadel/zitadel-charts/pull/325/files) recently.
I thought leaving repository_dispatch would make sure the pipelines in Zitadel keep succeeding.
[It turns out they need workflow_dispatch, not repository_dispatch](https://github.com/zitadel/zitadel/actions/runs/14132072401/job/39596105609).
This PR reverts the triggers to the state they were when everything worked.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
