### PR TITLE
fix: correct labels and selector labels

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # Please set the version explicitly using the appVersion variable if you need a newer Zitadel version.
 # The upcoming version 9 will include the latest Zitadel version by default (Zitadel v3).
 appVersion: v2.67.2
-version: 8.13.1
+version: 8.13.2
 kubeVersion: '>= 1.21.0-0'
 icon: https://zitadel.com/zitadel-logo-dark.svg
 maintainers:

--- a/charts/zitadel/templates/_helpers.tpl
+++ b/charts/zitadel/templates/_helpers.tpl
@@ -41,6 +41,38 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
+Init component labels
+*/}}
+{{- define "zitadel.init.labels" -}}
+{{ include "zitadel.labels" . }}
+{{ include "zitadel.init.selectorLabels" . }}
+{{- end }}
+
+{{/*
+Setup component labels
+*/}}
+{{- define "zitadel.setup.labels" -}}
+{{ include "zitadel.labels" . }}
+{{ include "zitadel.setup.selectorLabels" . }}
+{{- end }}
+
+{{/*
+Start component labels
+*/}}
+{{- define "zitadel.start.labels" -}}
+{{ include "zitadel.labels" . }}
+{{ include "zitadel.start.selectorLabels" . }}
+{{- end }}
+
+{{/*
+Debug component labels
+*/}}
+{{- define "zitadel.debug.labels" -}}
+{{ include "zitadel.labels" . }}
+{{ include "zitadel.debug.selectorLabels" . }}
+{{- end }}
+
+{{/*
 Selector labels
 */}}
 {{- define "zitadel.selectorLabels" -}}
@@ -49,11 +81,42 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Debug Selector labels
+Component selector label
 */}}
-{{- define "zitadel.debugSelectorLabels" -}}
-app.kubernetes.io/name: {{ include "zitadel.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}-debug
+{{- define "zitadel.componentSelectorLabels" -}}
+app.kubernetes.io/component: {{ . }}
+{{- end }}
+
+{{/*
+Init component selector labels
+*/}}
+{{- define "zitadel.init.selectorLabels" -}}
+{{ include "zitadel.selectorLabels" . }}
+{{ include "zitadel.componentSelectorLabels" "init" }}
+{{- end }}
+
+{{/*
+Setup component selector labels
+*/}}
+{{- define "zitadel.setup.selectorLabels" -}}
+{{ include "zitadel.selectorLabels" . }}
+{{ include "zitadel.componentSelectorLabels" "setup" }}
+{{- end }}
+
+{{/*
+Start component selector labels
+*/}}
+{{- define "zitadel.start.selectorLabels" -}}
+{{ include "zitadel.selectorLabels" . }}
+{{ include "zitadel.componentSelectorLabels" "start" }}
+{{- end }}
+
+{{/*
+Debug component selector labels
+*/}}
+{{- define "zitadel.debug.selectorLabels" -}}
+{{ include "zitadel.selectorLabels" . }}
+{{ include "zitadel.componentSelectorLabels" "debug" }}
 {{- end }}
 
 {{/*

--- a/charts/zitadel/templates/debug_replicaset.yaml
+++ b/charts/zitadel/templates/debug_replicaset.yaml
@@ -4,7 +4,7 @@ kind: ReplicaSet
 metadata:
   name: "{{ include "zitadel.fullname" . }}-debug"
   labels:
-    app.kubernetes.io/component: debug
+    {{- include "zitadel.debug.labels" . | nindent 4 }}
   {{- with .Values.zitadel.debug.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -13,7 +13,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "zitadel.debugSelectorLabels" . | nindent 6 }}
+      {{- include "zitadel.debug.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -21,7 +21,7 @@ spec:
         checksum/secret-db-ssl-ca-crt: {{ include (print $.Template.BasePath "/secret_db-ssl-ca-crt.yaml") . | sha256sum }}
         checksum/secret-zitadel-secrets: {{ include (print $.Template.BasePath "/secret_zitadel-secrets.yaml") . | sha256sum }}
       labels:
-        {{- include "zitadel.debugSelectorLabels" . | nindent 8 }}
+        {{- include "zitadel.debug.labels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/zitadel/templates/deployment.yaml
+++ b/charts/zitadel/templates/deployment.yaml
@@ -3,8 +3,7 @@ kind: Deployment
 metadata:
   name: {{ include "zitadel.fullname" . }}
   labels:
-    {{- include "zitadel.labels" . | nindent 4 }}
-    app.kubernetes.io/component: start
+    {{- include "zitadel.start.labels" . | nindent 4 }}
   {{- with .Values.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -13,7 +12,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      {{- include "zitadel.selectorLabels" . | nindent 6 }}
+      {{- include "zitadel.start.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -24,8 +23,7 @@ spec:
         checksum/secret-db-ssl-ca-crt: {{ include (print $.Template.BasePath "/secret_db-ssl-ca-crt.yaml") . | sha256sum }}
         checksum/secret-zitadel-secrets: {{ include (print $.Template.BasePath "/secret_zitadel-secrets.yaml") . | sha256sum }}
       labels:
-        app.kubernetes.io/component: start
-        {{- include "zitadel.selectorLabels" . | nindent 8 }}
+        {{- include "zitadel.start.labels" . | nindent 8 }}
         {{- with .Values.podAdditionalLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/zitadel/templates/initjob.yaml
+++ b/charts/zitadel/templates/initjob.yaml
@@ -4,8 +4,7 @@ kind: Job
 metadata:
   name: "{{ include "zitadel.fullname" . }}-init"
   labels:
-    {{- include "zitadel.labels" . | nindent 4 }}
-    app.kubernetes.io/component: init
+    {{- include "zitadel.init.labels" . | nindent 4 }}
     {{- with .Values.initJob.annotations }}
   annotations:
       {{- toYaml . | nindent 4 }}
@@ -16,8 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "zitadel.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: init
+        {{- include "zitadel.init.labels" . | nindent 8 }}
         {{- with .Values.initJob.podAdditionalLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/zitadel/templates/pdb.yaml
+++ b/charts/zitadel/templates/pdb.yaml
@@ -8,7 +8,7 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ include "zitadel.fullname" . }}
   labels:
-    {{- include "zitadel.labels" . | nindent 4 }}
+    {{- include "zitadel.start.labels" . | nindent 4 }}
   {{- with .Values.pdb.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -26,5 +26,5 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "zitadel.selectorLabels" . | nindent 6 }}
+      {{- include "zitadel.start.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/charts/zitadel/templates/servicemonitor.yaml
+++ b/charts/zitadel/templates/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Values.metrics.serviceMonitor.namespace }}
   {{- end }}
   labels:
-    {{- include "zitadel.labels" . | nindent 4 }}
+    {{- include "zitadel.start.labels" . | nindent 4 }}
     {{- if .Values.metrics.serviceMonitor.additionalLabels }}
         {{- toYaml .Values.metrics.serviceMonitor.additionalLabels | nindent 4 }}
     {{- end }}
@@ -47,5 +47,5 @@ spec:
     - "{{ $.Release.Namespace }}"
   selector:
     matchLabels:
-    {{- include "zitadel.selectorLabels" . | nindent 6 }}
+    {{- include "zitadel.start.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/charts/zitadel/templates/setupjob.yaml
+++ b/charts/zitadel/templates/setupjob.yaml
@@ -6,8 +6,7 @@ kind: Job
 metadata:
   name: "{{ include "zitadel.fullname" . }}-setup"
   labels:
-    {{- include "zitadel.labels" . | nindent 4 }}
-    app.kubernetes.io/component: setup
+    {{- include "zitadel.setup.labels" . | nindent 4 }}
     {{- with .Values.setupJob.annotations }}
   annotations:
       {{- toYaml . | nindent 4 }}
@@ -18,8 +17,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "zitadel.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: setup
+        {{- include "zitadel.setup.labels" . | nindent 8 }}
         {{- with .Values.setupJob.podAdditionalLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
The deployment was missing a component label, so that its pods could be differentiated from those of the other components (init and setup jobs). This led the pod disruption budget to match pods of the other components, making draining of nodes (for example during a rolling replace of a node group) fail.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
