### PR TITLE
fix: avoid duplicate labels

### DIFF
--- a/charts/zitadel/templates/_helpers.tpl
+++ b/charts/zitadel/templates/_helpers.tpl
@@ -45,7 +45,7 @@ Init component labels
 */}}
 {{- define "zitadel.init.labels" -}}
 {{ include "zitadel.labels" . }}
-{{ include "zitadel.init.selectorLabels" . }}
+{{ include "zitadel.componentSelectorLabels" "init" }}
 {{- end }}
 
 {{/*
@@ -53,7 +53,7 @@ Setup component labels
 */}}
 {{- define "zitadel.setup.labels" -}}
 {{ include "zitadel.labels" . }}
-{{ include "zitadel.setup.selectorLabels" . }}
+{{ include "zitadel.componentSelectorLabels" "setup" }}
 {{- end }}
 
 {{/*
@@ -61,7 +61,7 @@ Start component labels
 */}}
 {{- define "zitadel.start.labels" -}}
 {{ include "zitadel.labels" . }}
-{{ include "zitadel.start.selectorLabels" . }}
+{{ include "zitadel.componentSelectorLabels" "start" }}
 {{- end }}
 
 {{/*
@@ -69,7 +69,7 @@ Debug component labels
 */}}
 {{- define "zitadel.debug.labels" -}}
 {{ include "zitadel.labels" . }}
-{{ include "zitadel.debug.selectorLabels" . }}
+{{ include "zitadel.componentSelectorLabels" "debug" }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
With #339 we introduced a bug that causes templating to fail because of duplicate labels.
This PR ensures that component labels are not duplicated anymore.

Closes #341 

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
