### PR TITLE
Remove hardcoded zitadel configmap name

### DIFF
--- a/charts/zitadel/templates/configmap.yaml
+++ b/charts/zitadel/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: zitadel-config-yaml
+  name: {{ include "zitadel.fullname" . }}-config
   {{- with .Values.configMap.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/zitadel/templates/debug_replicaset.yaml
+++ b/charts/zitadel/templates/debug_replicaset.yaml
@@ -107,7 +107,7 @@ spec:
       volumes:
       - name: zitadel-config-yaml
         configMap:
-          name: zitadel-config-yaml
+          name: {{ include "zitadel.fullname" . }}-config
       {{- if .Values.zitadel.secretConfig }}
       - name: zitadel-secrets-yaml
         secret:

--- a/charts/zitadel/templates/deployment.yaml
+++ b/charts/zitadel/templates/deployment.yaml
@@ -233,7 +233,7 @@ spec:
       volumes:
       - name: zitadel-config-yaml
         configMap:
-          name: zitadel-config-yaml
+          name: {{ include "zitadel.fullname" . }}-config
       {{- if .Values.zitadel.secretConfig }}
       - name: zitadel-secrets-yaml
         secret:

--- a/charts/zitadel/templates/initjob.yaml
+++ b/charts/zitadel/templates/initjob.yaml
@@ -143,7 +143,7 @@ spec:
       volumes:
       - name: zitadel-config-yaml
         configMap:
-          name: zitadel-config-yaml
+          name: {{ include "zitadel.fullname" . }}-config
           defaultMode: 0440
       {{- if .Values.zitadel.secretConfig }}
       - name: zitadel-secrets-yaml

--- a/charts/zitadel/templates/setupjob.yaml
+++ b/charts/zitadel/templates/setupjob.yaml
@@ -168,7 +168,7 @@ spec:
       volumes:
       - name: zitadel-config-yaml
         configMap:
-          name: zitadel-config-yaml
+          name: {{ include "zitadel.fullname" . }}-config
           defaultMode: 0440
       {{- if .Values.zitadel.secretConfig }}
       - name: zitadel-secrets-yaml


### PR DESCRIPTION
This PR aims to remove the harcoded configmap name used in helm chart template files to allow deploying zitadel multiple times in the same namespace

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
