### PR TITLE
feat: use Zitadel v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,9 @@ For more sofisticated production-ready configurations, follow one of the followi
 
 All the configurations from the examples above are guaranteed to work, because they are directly used in automatic acceptance tests.
 
-## Upgrade From V8 to V9 Release Candidate
+## Upgrade From V8 to V9
 
-The v9 charts default Zitadel and login versions reference [the second Zitadel v4 release candidate](https://github.com/zitadel/zitadel/releases/tag/v4.0.0-rc.2).
-Therefore, the chart version 9 is also marked as a release candidate.
+The v9 charts default Zitadel and login versions reference [Zitadel v4](https://github.com/zitadel/zitadel/releases/tag/v4.0.0).
 
 ### Don’t Switch to the New Login Deployment
 

--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: zitadel
 description: A Helm chart for ZITADEL
 type: application
-appVersion: v4.0.0-rc.2
-version: 9.0.0-rc.2
+appVersion: v4.0.0
+version: 9.0.0
 kubeVersion: '>= 1.21.0-0'
 icon: https://zitadel.com/zitadel-logo-dark.svg
 maintainers:


### PR DESCRIPTION
We released Zitadel v4.
We are not aware of any issues relating to the charts v9-rc2 release.
Therefore, we remove the pre-release status from the Chart, too.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
