### PR TITLE
fix: pay attention to FirstInstance.Skip

### DIFF
--- a/charts/zitadel/templates/setupjob.yaml
+++ b/charts/zitadel/templates/setupjob.yaml
@@ -152,7 +152,7 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.setupJob.resources | nindent 12 }}
-        {{- if include "deepCheck" (dict "root" .Values "path" (splitList "." "zitadel.configmapConfig.FirstInstance.Org.Machine")) }}
+        {{- if and (not .Values.zitadel.configmapConfig.FirstInstance.Skip) (include "deepCheck" (dict "root" .Values "path" (splitList "." "zitadel.configmapConfig.FirstInstance.Org.Machine"))) }}
         - name: "{{ .Chart.Name}}-machinekey"
           securityContext:
             {{- toYaml .Values.securityContext | nindent 14 }}
@@ -174,7 +174,7 @@ spec:
             {{- toYaml .Values.setupJob.resources | nindent 12 }}
           {{- end }}
       {{- end }}
-      {{- if include "deepCheck" (dict "root" .Values "path" (splitList "." "zitadel.configmapConfig.FirstInstance.Org.LoginClient")) }}
+      {{- if and (not .Values.zitadel.configmapConfig.FirstInstance.Skip) (include "deepCheck" (dict "root" .Values "path" (splitList "." "zitadel.configmapConfig.FirstInstance.Org.LoginClient"))) }}
         - name: "{{ .Chart.Name}}-login-client-pat"
           securityContext:
             {{- toYaml .Values.securityContext | nindent 14 }}


### PR DESCRIPTION
If FirstIntance.Skip is selected there is no instance to extract login-client-pat/machienkey from. Nevertheless the commands are executed and you would need to set a matching repository if you are behind a proxy.

This change disables the usage of kubectl when FirstInstance.Skip is enabled.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
