### PR TITLE
chore: add OCI image publishing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,22 +12,34 @@ jobs:
 
     permissions:
       contents: 'write'
+      packages: 'write'
       id-token: 'write'
 
     steps:
-    - id: 'checkout'
-      uses: 'actions/checkout@v5'
-      with:
-        fetch-depth: "0"
+      - id: 'checkout'
+        uses: 'actions/checkout@v5'
+        with:
+          fetch-depth: "0"
 
-    - id: 'configure-git'
-      run: |
-        git config user.name "$GITHUB_ACTOR"
-        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - id: 'configure-git'
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-    - id: 'release'
-      uses: 'helm/chart-releaser-action@v1.7.0'
-      env:
-        CR_GENERATE_RELEASE_NOTES: 'true'
-        CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - id: 'release'
+        uses: 'helm/chart-releaser-action@v1.7.0'
+        env:
+          CR_GENERATE_RELEASE_NOTES: 'true'
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
+      - id: 'login-ghcr'
+        name: 'Login to GitHub Container Registry'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - id: 'package-and-push-oci'
+        name: 'Package and Push OCI Image'
+        run: |
+          CHART_VERSION=$(grep '^version:' charts/zitadel/Chart.yaml | awk '{print $2}')
+          helm package charts/zitadel
+          helm push zitadel-${CHART_VERSION}.tgz oci://ghcr.io/${{ github.repository_owner }}/zitadel-charts


### PR DESCRIPTION
Adds OCI image publishing to the release workflow to push Helm charts as OCI artifacts to GitHub Container Registry alongside the existing GitHub Pages releases.

Closes #321 

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
