### PR TITLE
feat(chart): add graceful shutdown via preStop hook

### DIFF
--- a/charts/zitadel/templates/deployment_login.yaml
+++ b/charts/zitadel/templates/deployment_login.yaml
@@ -47,6 +47,12 @@ spec:
           env:
             - name: NEXT_PUBLIC_BASE_PATH
               value: /ui/v2/login
+          {{- if .Values.preStopHook.enabled }}
+          lifecycle:
+            preStop:
+              exec:
+                command: [ "/bin/sh", "-c", "sleep {{ .Values.preStopHook.sleepSeconds }}" ]
+          {{- end }}
           ports:
           - containerPort: {{ include "login.containerPort" . }}
             name: {{ .Values.login.service.protocol }}-server

--- a/charts/zitadel/templates/deployment_zitadel.yaml
+++ b/charts/zitadel/templates/deployment_zitadel.yaml
@@ -103,6 +103,12 @@ spec:
             - secretRef:
                 name: {{ .Values.envVarsSecret }}
           {{- end }}
+          {{- if .Values.preStopHook.enabled }}
+          lifecycle:
+            preStop:
+              exec:
+                command: [ "/bin/sh", "-c", "sleep {{ .Values.preStopHook.sleepSeconds }}" ]
+          {{- end }}
           ports:
           - containerPort: {{ include "zitadel.containerPort" . }}
             name: {{ .Values.service.protocol }}-server

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -406,6 +406,22 @@ pdb:
   # maxUnavailable: 1
   annotations: {}
 
+# Configures a preStop lifecycle hook for the main ZITADEL container to ensure
+# zero-downtime deployments.
+# When a pod is terminated, Kubernetes first removes it from the service endpoints
+# and then runs this hook. The 'sleep' command creates a crucial grace period.
+# This delay allows ingress controllers (like NGINX, Traefik) or service meshes
+# to update their routing tables and stop sending traffic to the terminating pod
+# *before* the ZITADEL process actually exits. This prevents the "502 Bad Gateway"
+# errors commonly seen during rolling updates.
+preStopHook:
+  # Set to true to enable the graceful shutdown delay. Recommended for all production environments.
+  enabled: true
+  # The duration (in seconds) to pause before allowing the container to be terminated.
+  # This value should be long enough for your cluster's networking layer to react
+  # to the endpoint removal. 15 seconds is a safe default for most environments.
+  sleepSeconds: 15
+
 # extraContainers allows you to add any sidecar containers you wish to use in the Zitadel pod.
 extraContainers: []
 


### PR DESCRIPTION
Implement a configurable preStop lifecycle hook to ensure zero-downtime deployments for both the ZITADEL and ZITADEL Login pods.

During rolling updates, pods can terminate faster than the ingress controller updates its endpoints, leading to a race condition that results in '502 Bad Gateway' errors.

This change introduces a configurable sleep delay that executes after the pod is removed from the service endpoints but before the main process is terminated. This grace period allows the network routing to stabilize, preventing traffic from being sent to a terminated pod.

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
