### PR TITLE
feat: add example for Insecure CloudNativePG Postgres Example

### DIFF
--- a/examples/6-cloudnativepg-insecure/README.md
+++ b/examples/6-cloudnativepg-insecure/README.md
@@ -1,0 +1,27 @@
+# Insecure CloudNativePG Postgres Example
+
+By running the commands below, you deploy a simple insecure Postgres database to your Kubernetes cluster [by using the CloudNativePG (CNPG)](https://github.com/cloudnative-pg/cloudnative-pg).
+Also, you deploy [a correctly configured ZITADEL](https://artifacthub.io/packages/helm/zitadel/zitadel).
+
+> [!WARNING]  
+> Anybody with network access to the Postgres database can connect to it and read and write data.
+> Use this example only for testing purposes.
+> For deploying a secure Postgres database, see [the secure Postgres example](../2-postgres-secure/README.md).
+
+> [!INFO]
+> The example assumes you already have a running Kubernetes cluster with a working ingress controller.
+> If you don't, [run a local KinD cluster](../99-kind-with-traefik/README.md) before executing the follwing commands.
+
+```bash
+# Install Postgres
+kubectl apply --server-side -f \
+  https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.27/releases/cnpg-1.27.0.yaml
+kubectl apply -f https://raw.githubusercontent.com/zitadel/zitadel-charts/main/examples/6-cloudnativepg-insecure/postgres-cluster.yaml
+
+
+# Install Zitadel
+helm repo add zitadel https://charts.zitadel.com
+helm install my-zitadel zitadel/zitadel --values https://raw.githubusercontent.com/zitadel/zitadel-charts/main/examples/1-postgres-insecure/zitadel-values.yaml
+```
+
+When Zitadel is ready, open https://pg-insecure.127.0.0.1.sslip.io/ui/console?login_hint=zitadel-admin@zitadel.pg-insecure.127.0.0.1.sslip.io in your browser and log in with the password `Password1!`.

--- a/examples/6-cloudnativepg-insecure/postgres-cluster.yaml
+++ b/examples/6-cloudnativepg-insecure/postgres-cluster.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: superuser-secret
+type: kubernetes.io/basic-auth
+stringData:
+  username: postgres
+  password: postgres
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: db-postgresql
+spec:
+  instances: 1
+
+  storage:
+    size: 2Gi
+
+  enableSuperuserAccess: true
+  superuserSecret:
+    name: superuser-secret

--- a/examples/6-cloudnativepg-insecure/zitadel-values.yaml
+++ b/examples/6-cloudnativepg-insecure/zitadel-values.yaml
@@ -1,0 +1,31 @@
+zitadel:
+  masterkey: x123456789012345678901234567891y
+  configmapConfig:
+    ExternalDomain: pg-insecure.127.0.0.1.sslip.io
+    ExternalPort: 443
+    TLS:
+      Enabled: false
+    Database:
+      Postgres:
+        Host: db-postgresql-rw
+        Port: 5432
+        Database: zitadel
+        MaxOpenConns: 20
+        MaxIdleConns: 10
+        MaxConnLifetime: 30m
+        MaxConnIdleTime: 5m
+        User:
+          Username: postgres
+          Password: postgres
+          SSL:
+            Mode: disable
+        Admin:
+          Username: postgres
+          Password: postgres
+          SSL:
+            Mode: disable
+ingress:
+  enabled: true
+login:
+  ingress:
+    enabled: true


### PR DESCRIPTION

Hey team, I’m adding an example that uses CloudNativePG instead of the Bitnami Postgres chart. CloudNativePG is a Kubernetes-native Postgres solution.

Let me know if you have any concerns.

### Definition of Ready

- [x ] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
