### PR TITLE
feat(login): add support for environment variables in login deployment

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: v4.0.0
-version: 9.4.0
+version: 9.5.0
 kubeVersion: '>= 1.21.0-0'
 icon: https://zitadel.com/zitadel-logo-dark.svg
 maintainers:

--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: v4.0.0
-version: 9.3.0
+version: 9.4.0
 kubeVersion: '>= 1.21.0-0'
 icon: https://zitadel.com/zitadel-logo-dark.svg
 maintainers:

--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: v4.0.0
-version: 9.5.0
+version: 9.4.0
 kubeVersion: '>= 1.21.0-0'
 icon: https://zitadel.com/zitadel-logo-dark.svg
 maintainers:

--- a/charts/zitadel/templates/deployment_login.yaml
+++ b/charts/zitadel/templates/deployment_login.yaml
@@ -47,6 +47,9 @@ spec:
           env:
             - name: NEXT_PUBLIC_BASE_PATH
               value: /ui/v2/login
+            {{- with .Values.login.env }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
           - containerPort: {{ include "login.containerPort" . }}
             name: {{ .Values.login.service.protocol }}-server

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -236,7 +236,7 @@ login:
   topologySpreadConstraints: []
   # Additional environment variables
   env:
-    [ ]
+    []
     # - name: ZITADEL_DATABASE_POSTGRES_HOST
     #   valueFrom:
     #     secretKeyRef:

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -230,6 +230,14 @@ login:
   tolerations: []
   affinity: {}
   topologySpreadConstraints: []
+  # Additional environment variables
+  env:
+    [ ]
+    # - name: ZITADEL_DATABASE_POSTGRES_HOST
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: postgres-pguser-postgres
+    #       key: host
 
 replicaCount: 3
 


### PR DESCRIPTION
This change introduces `login.env` and `login.envVarsSecret` in values.yaml and wires them into the login Deployment template. Users can now provide static environment variables or reference a Kubernetes Secret in the same way the main zitadel deployment supports them. The default `NEXT_PUBLIC_BASE_PATH=/ui/v2/login` is still included, and any additional variables defined under `login.env` will be appended. This keeps the login deployment consistent with the existing zitadel setup while enabling customization of runtime environment.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
