### PR TITLE
fix: correct alpine/k8s image tag

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: v4.2.0
-version: 9.5.3
+version: 9.5.4
 kubeVersion: '>= 1.21.0-0'
 icon: https://zitadel.com/zitadel-logo-dark.svg
 maintainers:

--- a/charts/zitadel/templates/_helpers.tpl
+++ b/charts/zitadel/templates/_helpers.tpl
@@ -297,3 +297,8 @@ Database SSL CA certificate Secret name
 {{ include "zitadel.fullname" . }}-db-ssl-ca-crt
 {{- end -}}
 {{- end -}}
+
+{{- define "zitadel.kubeversion" -}}
+{{- $version := semver .Capabilities.KubeVersion.Version -}}
+{{- printf "%d.%d.%d" $version.Major $version.Minor $version.Patch -}}
+{{- end -}}

--- a/charts/zitadel/templates/setupjob.yaml
+++ b/charts/zitadel/templates/setupjob.yaml
@@ -156,7 +156,7 @@ spec:
         - name: "{{ .Chart.Name}}-machinekey"
           securityContext:
             {{- toYaml .Values.securityContext | nindent 14 }}
-          image: "{{ .Values.setupJob.machinekeyWriter.image.repository }}:{{ .Values.setupJob.machinekeyWriter.image.tag | default (.Capabilities.KubeVersion.GitVersion | trimPrefix "v") }}"
+          image: "{{ .Values.setupJob.machinekeyWriter.image.repository }}:{{ .Values.setupJob.machinekeyWriter.image.tag | default (include "zitadel.kubeversion" .) }}"
           command: [ "sh","-c","until [ ! -z $(kubectl -n {{ .Release.Namespace }} get po ${POD_NAME} -o jsonpath=\"{.status.containerStatuses[?(@.name=='{{ .Chart.Name }}-setup')].state.terminated}\") ]; do echo 'waiting for {{ .Chart.Name }}-setup container to terminate'; sleep 5; done && echo '{{ .Chart.Name }}-setup container terminated' && if [ -f /machinekey/sa.json ]; then kubectl -n {{ .Release.Namespace }} create secret generic {{ .Values.zitadel.configmapConfig.FirstInstance.Org.Machine.Machine.Username }} --from-file={{ .Values.zitadel.configmapConfig.FirstInstance.Org.Machine.Machine.Username }}.json=/machinekey/sa.json; fi;" ]
           env:
             - name: POD_NAME
@@ -178,7 +178,7 @@ spec:
         - name: "{{ .Chart.Name}}-login-client-pat"
           securityContext:
             {{- toYaml .Values.securityContext | nindent 14 }}
-          image: "{{ .Values.setupJob.machinekeyWriter.image.repository }}:{{ .Values.setupJob.machinekeyWriter.image.tag | default (.Capabilities.KubeVersion.GitVersion | trimPrefix "v") }}"
+          image: "{{ .Values.setupJob.machinekeyWriter.image.repository }}:{{ .Values.setupJob.machinekeyWriter.image.tag | default (include "zitadel.kubeversion" .) }}"
           command: [ "sh","-c","until [ ! -z $(kubectl -n {{ .Release.Namespace }} get po ${POD_NAME} -o jsonpath=\"{.status.containerStatuses[?(@.name=='{{ .Chart.Name }}-setup')].state.terminated}\") ]; do echo 'waiting for {{ .Chart.Name }}-setup container to terminate'; sleep 5; done && echo '{{ .Chart.Name }}-setup container terminated' && if [ -f /login-client/pat ]; then kubectl -n {{ .Release.Namespace }} create secret generic {{ .Values.login.loginClientSecretPrefix }}login-client --from-file=pat=/login-client/pat; fi;" ]
           env:
             - name: POD_NAME


### PR DESCRIPTION
Hello,

The current `alpine/k8s` image tag uses the full `kubeversion` which can contain pre-release and or build metadata information. This leads to invalid tags. This PR change this to only use the major, minor and patch components of `kubeversion`.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
