### PR TITLE
feat: Replace cert `initContainer` with `genSelfSignedCert`

### DIFF
--- a/charts/zitadel/templates/deployment_zitadel.yaml
+++ b/charts/zitadel/templates/deployment_zitadel.yaml
@@ -215,28 +215,6 @@ spec:
       {{- with .Values.zitadel.initContainers }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.zitadel.selfSignedCert.enabled }}
-        - name: generate-self-signed-cert
-          image: alpine/openssl
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-          volumeMounts:
-            - name: tls
-              mountPath: "/etc/tls"
-          command:
-            - "/bin/ash"
-            - "-c"
-            - "openssl req -nodes -x509 -sha256 -newkey rsa:4096 -keyout /etc/tls/tls.key -out /etc/tls/tls.crt -days 3560 -subj \"/CN=ZITADEL Chart Demo\" -addext \"subjectAltName = DNS:localhost,DNS:${POD_IP},DNS:${POD_NAME}{{- if .Values.zitadel.configmapConfig.ExternalDomain -}},DNS:{{- .Values.zitadel.configmapConfig.ExternalDomain -}}{{- end -}}{{- if .Values.zitadel.selfSignedCert.additionalDnsName -}},DNS:{{- .Values.zitadel.selfSignedCert.additionalDnsName -}}{{- end -}}\""
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-      {{- end }}
       {{- end }}
       volumes:
       - name: zitadel-config-yaml
@@ -280,7 +258,8 @@ spec:
       {{- end }}
       {{- if .Values.zitadel.selfSignedCert.enabled }}
       - name: tls
-        emptyDir: {}
+        secret:
+          secretName: {{ include "zitadel.fullname" . }}-self-signed-tls
       {{- end }}
       {{- with .Values.extraVolumes }}
       {{- toYaml . | nindent 6 }}

--- a/charts/zitadel/templates/secret_self-signed.yaml
+++ b/charts/zitadel/templates/secret_self-signed.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.zitadel.selfSignedCert.enabled }}
+{{- $cn := .Values.zitadel.configmapConfig.ExternalDomain | default (include "zitadel.fullname" .) }}
+{{- $sans := list $cn "localhost" }}
+{{- if .Values.zitadel.selfSignedCert.additionalDnsName }}
+{{- $sans = append $sans .Values.zitadel.selfSignedCert.additionalDnsName }}
+{{- end }}
+{{- $cert := genSelfSignedCert $cn nil $sans 3650 }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "zitadel.fullname" . }}-self-signed-tls
+  labels:
+  {{ include "zitadel.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $cert.Cert | b64enc }}
+  tls.key: {{ $cert.Key | b64enc }}
+{{- end }}

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -73,13 +73,22 @@ zitadel:
   # The Secret containing the certificate at key tls.crt and tls.key for listening on HTTPS
   serverSslCrtSecret: ""
 
-  # Generate a self-signed certificate using an init container
-  # This will also mount the generated files to /etc/tls/ so that you can reference them in the pod.
-  # E.G. KeyPath: /etc/tls/tls.key CertPath: /etc/tls/tls.crt
-  # By default, the SAN DNS names include, localhost, the POD IP address and the POD name. You may include one more by using additionalDnsName like "my.zitadel.fqdn".
+  # Generate a self-signed TLS certificate using Helm's native functions.
+  # If enabled, this creates a Kubernetes secret containing a self-signed
+  # certificate and mounts it to /etc/tls/ in the ZITADEL pod.
+  #
+  # This is useful for quick demos or test environments without an ingress
+  # controller. It is NOT recommended for production use.
+  #
+  # The certificate will be valid for the `ExternalDomain`, `localhost`,
+  # and any host specified in `additionalDnsName`. It can't use dynamic
+  # values like the Pod IP, which the previous initContainer method did.
   selfSignedCert:
+    # -- If true, enables the generation of the self-signed certificate.
     enabled: false
-    additionalDnsName:
+    # -- An additional DNS name (SAN) to add to the certificate.
+    # e.g., "my-zitadel.example.com"
+    additionalDnsName: ""
 
   # Enabling this will create a debug pod that can be used to inspect the ZITADEL configuration and run zitadel commands using the zitadel binary.
   # This is useful for debugging and troubleshooting.


### PR DESCRIPTION
This change refactors the self-signed certificate generation feature to align with Helm best practices and simplify the chart's logic.

It replaces the previous implementation, which relied on an `initContainer` running `alpine/openssl`, with the more efficient, built-in Helm function `genSelfSignedCert`.

This simplification removes the dependency on an external image for this task and makes the chart easier to maintain. The new implementation creates a standard `kubernetes.io/tls` secret directly.

Closes #213 

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
