### PR TITLE
fix: resolve login client secret mount when using loginClientSecretPr…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .login-failures
+.go

--- a/charts/zitadel/templates/deployment_login.yaml
+++ b/charts/zitadel/templates/deployment_login.yaml
@@ -103,6 +103,12 @@ spec:
       - name: login-config-dotenv
         configMap:
           name: {{ include "login.configmapName" . }}
+      {{- if include "deepCheck" (dict "root" .Values "path" (splitList "." "zitadel.configmapConfig.FirstInstance.Org.LoginClient")) }}
+      - name: login-client
+        secret:
+          defaultMode: 444
+          secretName: {{ .Values.login.loginClientSecretPrefix }}login-client
+      {{- end }}
       {{- with .Values.login.extraVolumes }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
@@ -122,4 +128,4 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-  {{- end }}
+{{- end }}

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -149,12 +149,7 @@ login:
   - name: login-client
     mountPath: /login-client
     readOnly: true
-  extraVolumes:
-  - name: login-client
-    secret:
-      defaultMode: 444
-      # Adjust this if you want to reference a different secret for the login client PAT.
-      secretName: login-client
+  extraVolumes: []
   replicaCount: 3
   initContainers: []
   extraContainers: []


### PR DESCRIPTION
…efix

The login deployment was using a hardcoded 'login-client' secret name in extraVolumes, causing mount failures when loginClientSecretPrefix was set. This resulted in login pods stuck in ContainerCreating state.

Changes:
- Remove hardcoded login-client volume from values.yaml extraVolumes
- Add dynamic volume mounting in login deployment template
- Use loginClientSecretPrefix in secret name resolution
- Add conditional volume creation based on LoginClient configuration

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
