### PR TITLE
fix: Correct login replica count and adjust chart defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .login-failures
+.go

--- a/charts/zitadel/templates/deployment_login.yaml
+++ b/charts/zitadel/templates/deployment_login.yaml
@@ -13,7 +13,7 @@ spec:
   {{- if .Values.login.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.login.revisionHistoryLimit }}
   {{- end }}
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.login.replicaCount }}
   selector:
     matchLabels:
       {{- include "zitadel.login.selectorLabels" . | nindent 6 }}

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -155,7 +155,10 @@ login:
       defaultMode: 444
       # Adjust this if you want to reference a different secret for the login client PAT.
       secretName: login-client
-  replicaCount: 3
+  # Number of pod replicas. While a single replica is fine for testing,
+  # production environments should use 3 or more to prevent downtime during
+  # updates and ensure high availability.
+  replicaCount: 1
   initContainers: []
   extraContainers: []
   image:
@@ -244,7 +247,10 @@ login:
     #       key: host
   revisionHistoryLimit: 10
 
-replicaCount: 3
+# Number of pod replicas. While a single replica is fine for testing,
+# production environments should use 3 or more to prevent downtime during
+# updates and ensure high availability.
+replicaCount: 1
 
 image:
   repository: ghcr.io/zitadel/zitadel


### PR DESCRIPTION
This commit resolves a bug in the Helm chart where the login deployment was incorrectly using the global `.Values.replicaCount` instead of its own `.Values.login.replicaCount`. This prevented the login pods from being scaled independently and made the configuration misleading.

The template `templates/deployment_login.yaml` has been updated to reference the correct value.

As part of this correction, the default replica count for both the main and login deployments has been changed from 3 to 1. This aligns with Helm chart best practices, ensuring a smoother out-of-the-box experience on resource-constrained environments like Minikube. Comments have also been added to guide users on setting a higher replica count for production.

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
