### PR TITLE
fix(tests): Use bitnami legacy images and increase helm timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .login-failures
+.go

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: all
+all: test
+
+.PHONY: test
+test:
+	@echo "Running Go tests..."
+	@cd ./charts/zitadel/acceptance_test/ && go test -v -p 1 -timeout 30m

--- a/charts/zitadel/acceptance_test/before_test.go
+++ b/charts/zitadel/acceptance_test/before_test.go
@@ -2,8 +2,9 @@ package acceptance_test
 
 import (
 	"context"
-	"github.com/gruntwork-io/terratest/modules/helm"
 	"time"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
 )
 
 func (s *ConfigurationTest) BeforeTest(_, _ string) {
@@ -14,7 +15,7 @@ func (s *ConfigurationTest) BeforeTest(_, _ string) {
 		KubectlOptions: s.KubeOptions,
 		Version:        s.dbChart.version,
 		SetValues:      s.dbChart.testValues,
-		ExtraArgs:      map[string][]string{"install": {"--wait"}},
+		ExtraArgs:      map[string][]string{"install": {"--wait", "--timeout", "10m"}},
 	}
 	Awaitf(context.Background(), s.T(), 1*time.Minute, func(ctx context.Context) error {
 		err := helm.AddRepoE(s.T(), options, s.dbRepoName, s.dbChart.repoUrl)

--- a/charts/zitadel/acceptance_test/config_test.go
+++ b/charts/zitadel/acceptance_test/config_test.go
@@ -35,7 +35,10 @@ var (
 	Postgres = databaseChart{
 		repoUrl: "https://charts.bitnami.com/bitnami",
 		name:    "postgresql",
-		version: "12.10.0",
+		testValues: map[string]string{
+			"image.repository":                   "bitnamilegacy/postgresql",
+			"volumePermissions.image.repository": "bitnamilegacy/os-shell",
+		},
 	}
 )
 


### PR DESCRIPTION
Switches the acceptance tests to use the `bitnamilegacy` repository for both the PostgreSQL and os-shell images, aligning it with the smoke tests.

Increases the Helm installation timeout to 10 minutes to prevent failures in resource-constrained environments.

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
