### PR TITLE
chore: add kubeconform validation for Helm charts

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,11 +1,7 @@
 name: Typecheck
 
 on:
-  workflow_call:
-    inputs:
-      ref:
-        required: true
-        type: string
+  push:
 
 defaults:
   run:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,40 @@
+name: Typecheck
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+
+defaults:
+  run:
+    working-directory: ./
+
+permissions:
+  contents: read
+
+jobs:
+  steep-check:
+    runs-on: ubuntu-latest
+    name: Inspect Code
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Helm
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
+
+      - name: Setup kubeconform
+        uses: bmuschko/setup-kubeconform@v1 # v1
+
+      - name: Run make check
+        run: make check

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,15 @@ all: test
 test:
 	@echo "Running Go tests..."
 	@cd ./charts/zitadel/acceptance_test/ && go test -v -p 1 -timeout 30m
+
+# Validate Helm chart manifests using kubeconform. This renders the Helm chart
+# templates into Kubernetes YAML manifests and validates them against the K8s
+# API schemas. The masterkey is required for template rendering but is just a
+# placeholder value since we're only validating YAML structure, not deploying.
+.PHONY: check
+check:
+	@echo "Validating Helm charts..."
+	@helm template zitadel charts/zitadel \
+		--values charts/zitadel/values.yaml \
+		--set zitadel.masterkey="dGVzdC1tYXN0ZXJrZXktZm9yLXZhbGlkYXRpb24=" \
+		| kubeconform -strict -ignore-missing-schemas -summary

--- a/README.md
+++ b/README.md
@@ -186,20 +186,30 @@ The `.editorconfig` file in this repository defines:
 
 If your editor doesn't automatically pick up these settings, please install the appropriate EditorConfig plugin for your development environment.
 
-Lint the chart:
+#### Lint the chart:
 
 ```bash
 docker run -it --network host --workdir=/data --rm --volume $(pwd):/data quay.io/helmpack/chart-testing:v3.5.0 ct lint --charts charts/zitadel --target-branch main
 ```
 
-Test the chart:
+#### Validate Helm Charts
+
+Validate the Helm chart manifests against Kubernetes API schemas using kubeconform:
+
+```bash
+make check
+```
+
+This renders the chart templates and validates them for correctness without requiring a Kubernetes cluster.
+
+### Test the chart:
 
 ```bash
 # Create KinD cluster
 kind create cluster --config ./charts/zitadel/acceptance_test/kindConfig.yaml
 
 # Test the chart
-go test ./...
+make test
 ```
 
 Watch the Kubernetes pods if you want to see progress.


### PR DESCRIPTION
This PR adds Helm chart validation using kubeconform to catch manifest issues early in the CI pipeline. The validation runs via `make check`, which renders the Helm templates and validates them against Kubernetes API schemas without requiring a cluster. This helps ensure chart changes produce valid Kubernetes resources before they're tested or deployed.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
