### PR TITLE
fix: use semver parsing for setup job image tag

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: v4.2.0
-version: 9.7.4
+version: 9.7.5
 kubeVersion: '>= 1.30.0-0'
 icon: https://zitadel.com/zitadel-logo-dark.svg
 maintainers:

--- a/charts/zitadel/templates/_helpers.tpl
+++ b/charts/zitadel/templates/_helpers.tpl
@@ -297,3 +297,22 @@ Database SSL CA certificate Secret name
 {{ include "zitadel.fullname" . }}-db-ssl-ca-crt
 {{- end -}}
 {{- end -}}
+
+{{/*
+zitadel.kubeversion
+
+This helper template takes the Kubernetes cluster's version string, which
+can be complex (e.g., "v1.28.5+k3s1"), and returns a sanitized, clean
+version string in the "MAJOR.MINOR.PATCH" format. This is crucial for
+creating valid container image tags that won't fail on Kubernetes
+distributions with non-standard versioning schemes.
+
+Its logic first uses the `semver` function to parse the full version
+string, intelligently separating the core version numbers from extra
+suffixes. The `printf` function then rebuilds the string using only the
+major, minor, and patch components, guaranteeing a clean and valid output.
+*/}}
+{{- define "zitadel.kubeVersion" -}}
+{{- $version := semver .Capabilities.KubeVersion.Version -}}
+{{- printf "%d.%d.%d" $version.Major $version.Minor $version.Patch -}}
+{{- end -}}

--- a/charts/zitadel/templates/setupjob.yaml
+++ b/charts/zitadel/templates/setupjob.yaml
@@ -156,7 +156,7 @@ spec:
         - name: "{{ .Chart.Name}}-machinekey"
           securityContext:
             {{- toYaml .Values.securityContext | nindent 14 }}
-          image: "{{ .Values.setupJob.machinekeyWriter.image.repository }}:{{ .Values.setupJob.machinekeyWriter.image.tag | default (.Capabilities.KubeVersion.GitVersion | trimPrefix "v") }}"
+          image: "{{ .Values.setupJob.machinekeyWriter.image.repository }}:{{ .Values.setupJob.machinekeyWriter.image.tag | default (include "zitadel.kubeVersion" .) }}"
           command: [ "sh","-c","until [ ! -z $(kubectl -n {{ .Release.Namespace }} get po ${POD_NAME} -o jsonpath=\"{.status.containerStatuses[?(@.name=='{{ .Chart.Name }}-setup')].state.terminated}\") ]; do echo 'waiting for {{ .Chart.Name }}-setup container to terminate'; sleep 5; done && echo '{{ .Chart.Name }}-setup container terminated' && if [ -f /machinekey/sa.json ]; then kubectl -n {{ .Release.Namespace }} create secret generic {{ .Values.zitadel.configmapConfig.FirstInstance.Org.Machine.Machine.Username }} --from-file={{ .Values.zitadel.configmapConfig.FirstInstance.Org.Machine.Machine.Username }}.json=/machinekey/sa.json; fi;" ]
           env:
             - name: POD_NAME
@@ -178,7 +178,7 @@ spec:
         - name: "{{ .Chart.Name}}-login-client-pat"
           securityContext:
             {{- toYaml .Values.securityContext | nindent 14 }}
-          image: "{{ .Values.setupJob.machinekeyWriter.image.repository }}:{{ .Values.setupJob.machinekeyWriter.image.tag | default (.Capabilities.KubeVersion.GitVersion | trimPrefix "v") }}"
+          image: "{{ .Values.setupJob.machinekeyWriter.image.repository }}:{{ .Values.setupJob.machinekeyWriter.image.tag | default (include "zitadel.kubeVersion" .) }}"
           command: [ "sh","-c","until [ ! -z $(kubectl -n {{ .Release.Namespace }} get po ${POD_NAME} -o jsonpath=\"{.status.containerStatuses[?(@.name=='{{ .Chart.Name }}-setup')].state.terminated}\") ]; do echo 'waiting for {{ .Chart.Name }}-setup container to terminate'; sleep 5; done && echo '{{ .Chart.Name }}-setup container terminated' && if [ -f /login-client/pat ]; then kubectl -n {{ .Release.Namespace }} create secret generic {{ .Values.login.loginClientSecretPrefix }}login-client --from-file=pat=/login-client/pat; fi;" ]
           env:
             - name: POD_NAME


### PR DESCRIPTION
This pull request fixes a critical bug that caused Helm chart installations to fail on Kubernetes distributions like `k3s` and `EKS`. The setup job was creating an invalid container image tag because it used the cluster's full version string, which can include metadata suffixes like `+k3s1`. This resulted in `ImagePullBackOff` errors, blocking deployments. 

The solution introduces a new Helm helper that uses the `semver` function to intelligently parse the version string. This function separates the core `MAJOR.MINOR.PATCH` numbers from any extra suffixes, guaranteeing that the final image tag is always in a clean and valid format, such as `1.28.5`. 

With this change, the chart will deploy successfully on all Kubernetes platforms, including `k3s` and `EKS`, as the setup job will now use the correct image tag and complete without errors. This fix causes no regressions for standard Kubernetes clusters. 

Closes #408

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
