### PR TITLE
feat: login client as system user for easier deployment

### DIFF
--- a/charts/zitadel/templates/_helpers.tpl
+++ b/charts/zitadel/templates/_helpers.tpl
@@ -288,6 +288,17 @@ ZITADEL masterkey Secret name
 {{- end -}}
 
 {{/*
+ZITADEL login client Secret name
+*/}}
+{{- define "login.loginClientSecretName" -}}
+{{- if .Values.login.loginClientSecretName -}}
+{{ .Values.login.loginClientSecretName }}
+{{- else -}}
+{{ include "login.loginClientSecretPrefix" . }}-login-client
+{{- end -}}
+{{- end -}}
+
+{{/*
 Database SSL CA certificate Secret name
 */}}
 {{- define "zitadel.dbSslCaCrtSecretName" -}}

--- a/charts/zitadel/templates/configmap_login.yaml
+++ b/charts/zitadel/templates/configmap_login.yaml
@@ -14,7 +14,14 @@ data:
     {{- if .Values.login.customConfigmapConfig }}
     {{ .Values.login.customConfigmapConfig | nindent 4 }}
     {{- else }}
+      {{- if and (include "deepCheck" (dict "root" .Values "path" (splitList "." "zitadel.configmapConfig.FirstInstance.Org.LoginClient"))) (not (include "deepCheck" (dict "root" .Values "path" (splitList "." "zitadel.configmapConfig.FirstInstance.Skip")))) }}
       ZITADEL_SERVICE_USER_TOKEN_FILE="/login-client/pat"
+      {{- end }}
+      {{- if (or .Values.login.loginClientSecretName .Values.login.loginClientSecretPrivateKey)}}
+      AUDIENCE="http{{ if and .Values.zitadel.configmapConfig.TLS .Values.zitadel.configmapConfig.TLS.Enabled }}s{{ end }}://{{ include "zitadel.fullname" . }}:{{ .Values.service.port }}"
+      SYSTEM_USER_ID=login-system-user
+      SYSTEM_USER_PRIVATE_KEY_FILE=/login-client-secret/login-client-private-key
+      {{- end }}
       ZITADEL_API_URL="http{{ if and .Values.zitadel.configmapConfig.TLS .Values.zitadel.configmapConfig.TLS.Enabled }}s{{ end }}://{{ include "zitadel.fullname" . }}:{{ .Values.service.port }}"
       CUSTOM_REQUEST_HEADERS="Host:{{ .Values.zitadel.configmapConfig.ExternalDomain }}"
       {{- if .Values.zitadel.selfSignedCert.enabled }}

--- a/charts/zitadel/templates/deployment_login.yaml
+++ b/charts/zitadel/templates/deployment_login.yaml
@@ -97,6 +97,11 @@ spec:
             mountPath: /login-client
             readOnly: true
           {{- end }}
+          {{- if (or .Values.login.loginClientSecretName .Values.login.loginClientSecretPrivateKey)}}
+          - name: login-client-secret
+            mountPath: /login-client-secret
+            readOnly: true
+          {{- end }}
           {{- with .Values.login.extraVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
@@ -115,6 +120,12 @@ spec:
         secret:
           defaultMode: 444
           secretName: {{ .Values.login.loginClientSecretPrefix }}login-client
+      {{- end }}
+      {{- if (or .Values.login.loginClientSecretName .Values.login.loginClientSecretPrivateKey)}}
+      - name: login-client-secret
+        secret:
+          defaultMode: 444
+          secretName: {{ include "login.loginClientSecretName" . }}
       {{- end }}
       {{- with .Values.login.extraVolumes }}
       {{- toYaml . | nindent 6 }}

--- a/charts/zitadel/templates/deployment_zitadel.yaml
+++ b/charts/zitadel/templates/deployment_zitadel.yaml
@@ -207,6 +207,11 @@ spec:
           - name: tls
             mountPath: /etc/tls
           {{- end }}
+          {{- if (or .Values.login.loginClientSecretName .Values.login.loginClientSecretPrivateKey)}}
+          - name: login-client-secret
+            mountPath: /login-client-secret
+            readOnly: true
+          {{- end }}
           {{- with .Values.extraVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
@@ -283,6 +288,12 @@ spec:
       {{- if .Values.zitadel.selfSignedCert.enabled }}
       - name: tls
         emptyDir: {}
+      {{- end }}
+      {{- if (or .Values.login.loginClientSecretName .Values.login.loginClientSecretPrivateKey)}}
+      - name: login-client-secret
+        secret:
+          defaultMode: 444
+          secretName: {{ include "login.loginClientSecretName" . }}
       {{- end }}
       {{- with .Values.extraVolumes }}
       {{- toYaml . | nindent 6 }}

--- a/charts/zitadel/templates/secret_login-secrets.yaml
+++ b/charts/zitadel/templates/secret_login-secrets.yaml
@@ -1,0 +1,19 @@
+{{- if (or (and .Values.login.loginClientSecretName .Values.login.loginClientSecretPrivateKeyValue) (and (not .Values.login.loginClientSecretPrivateKeyValue) (not .Values.login.loginClientSecretName)) ) }}
+{{- fail "Either set .Values.login.loginClientSecretPrivateKeyValue xor .Values.login.loginClientSecretName" }}
+{{- end }}
+{{- if .Values.zitadel.masterkey -}}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "login.loginClientSecretName" . }}
+  {{- with .Values.login.loginClientSecretAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "zitadel.labels" . | nindent 4 }}
+stringData:
+  "login-client-private-key": {{ .Values.login.loginClientSecretPrivateKeyValue }}
+  "login-client-public-key": {{ .Values.login.loginClientSecretPublicKeyValue }}
+{{- end -}}

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -11,13 +11,12 @@ zitadel:
           Enabled: true
         Webhook:
           Enabled: false
-    FirstInstance:
-      Org:
-        LoginClient:
-          Machine:
-            Username: 'login-client'
-            Name: 'Automatically Initialized IAM Login Client'
-          Pat.ExpirationDate: '2029-01-01T00:00:00Z'
+    SystemAPIUsers:
+     - login-system-user:
+       Path: /login-client-secret/login-client-public-key
+       Memberships:
+         - MemberType: System
+           Roles: "IAM_LOGIN_CLIENT"
 
   # The ZITADEL config under secretConfig is written to a Kubernetes Secret
   # See all defaults here:
@@ -30,17 +29,17 @@ zitadel:
     helm.sh/hook-delete-policy: before-hook-creation
     helm.sh/hook-weight: "0"
 
-  # Reference the name of a secret that contains ZITADEL configuration.
-  configSecretName:
-  # The key under which the ZITADEL configuration is located in the secret.
-  configSecretKey: config-yaml
-
   # ZITADEL uses the masterkey for symmetric encryption.
   # You can generate it for example with tr -dc A-Za-z0-9 </dev/urandom | head -c 32
   masterkey: ""
   # Reference the name of the secret that contains the masterkey. The key should be named "masterkey".
   # Note: Either zitadel.masterkey or zitadel.masterkeySecretName must be set
   masterkeySecretName: ""
+
+  # Reference the name of a secret that contains ZITADEL login private and public key.
+  configSecretName:
+  # The key under which the ZITADEL configuration is located in the secret.
+  configSecretKey: config-yaml
 
   # Number of old ReplicaSets to retain for rollback purposes
   # Set to 0 to not keep any old ReplicaSets
@@ -199,6 +198,21 @@ login:
   # To deploy zitadel multiple times in the same namespace, use a loginClientSecretPrefix.
   # To mount it, also change the referenced secretName for the login client to "{loginClientSecretPrefix}login-client"
   loginClientSecretPrefix:
+
+  # Reference the name of a secret that contains ZITADEL login client private and public key.
+  # If not provided, loginClientSecretPrefix is used to generate private and public key.
+  loginClientSecretName:
+  # ZITADEL Login client private key value base64 encoded, if not provided key is generated
+  loginClientSecretPrivateKey:
+  # ZITADEL Login client public key value base64 encoded, if not provided or private key is empty key is generated
+  loginClientSecretPublicKey:
+
+  # Annotations set on login client secret
+  loginClientSecretAnnotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "0"
+
   extraVolumeMounts: []
   extraVolumes: []
   # Number of pod replicas. While a single replica is fine for testing,


### PR DESCRIPTION
For now only a WIP with first ideas on how to provide an option to use a system user as login client for easier deployment.

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
