### PR TITLE
ci: enable Qodana inspection on main branch

### DIFF
--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -1,6 +1,9 @@
 name: Qodana
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
 
 defaults:


### PR DESCRIPTION
Enables Qodana code inspection to run on the main branch in addition to pull requests. This allows Qodana to properly inspect the base branch for comparisons.

### Definition of Ready
- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes