### PR TITLE
docs: fix links

### DIFF
--- a/examples/2-postgres-secure/README.md
+++ b/examples/2-postgres-secure/README.md
@@ -15,11 +15,11 @@ kubectl wait --for=condition=complete job/create-certs
 
 # Install Postgres
 helm repo add bitnami https://charts.bitnami.com/bitnami
-helm install --wait db bitnami/postgresql --version 12.10.0 --values https://github.com/zitadel/zitadel-charts/blob/main/examples/2-postgres-secure/postgres-values.yaml
+helm install --wait db bitnami/postgresql --version 12.10.0 --values https://raw.githubusercontent.com/zitadel/zitadel-charts/refs/heads/main/examples/2-postgres-secure/postgres-values.yaml
 
 # Install Zitadel
 helm repo add zitadel https://charts.zitadel.com
-helm install my-zitadel zitadel/zitadel --values https://github.com/zitadel/zitadel-charts/blob/main/examples/2-postgres-secure/zitadel-values.yaml
+helm install my-zitadel zitadel/zitadel --values https://raw.githubusercontent.com/zitadel/zitadel-charts/refs/heads/main/examples/2-postgres-secure/zitadel-values.yaml
 ```
 
 When Zitadel is ready, open https://pg-secure.127.0.0.1.sslip.io/ui/console?login_hint=zitadel-admin@zitadel.pg-secure.127.0.0.1.sslip.io in your browser and log in with the password `Password1!`.


### PR DESCRIPTION
Fixes the links in the secure postgres example readme to reference the raw yamls instead of the GitHub HTML pages.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
