### PR TITLE
fix(login): make probes work with latest ZITADEL version

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: v4.2.0
-version: 9.13.0
+version: 9.13.1
 kubeVersion: '>= 1.30.0-0'
 icon: https://zitadel.com/zitadel-logo-dark.svg
 maintainers:

--- a/charts/zitadel/templates/deployment_login.yaml
+++ b/charts/zitadel/templates/deployment_login.yaml
@@ -65,6 +65,9 @@ spec:
               path: {{ include "login.livenessProbePath" . }}
               port: {{ .Values.login.service.protocol }}-server
               scheme: {{ .Values.login.service.scheme }}
+              httpHeaders:
+                - name: HOST
+                  value: {{ .Values.zitadel.configmapConfig.ExternalDomain }}
             initialDelaySeconds: {{ .Values.login.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.login.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.login.livenessProbe.failureThreshold }}
@@ -75,6 +78,9 @@ spec:
               path: {{ include "login.readinessProbePath" . }}
               port: {{ .Values.login.service.protocol }}-server
               scheme: {{ .Values.login.service.scheme }}
+              httpHeaders:
+                - name: HOST
+                  value: {{ .Values.zitadel.configmapConfig.ExternalDomain }}
             initialDelaySeconds: {{ .Values.login.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.login.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.login.readinessProbe.failureThreshold }}
@@ -85,6 +91,9 @@ spec:
               path: {{ include "login.startupProbePath" . }}
               port: {{ .Values.login.service.protocol }}-server
               scheme: {{ .Values.login.service.scheme }}
+              httpHeaders:
+                - name: HOST
+                  value: {{ .Values.zitadel.configmapConfig.ExternalDomain }}
             periodSeconds: {{ .Values.login.startupProbe.periodSeconds }}
             failureThreshold: {{ .Values.login.startupProbe.failureThreshold }}
           {{- end }}


### PR DESCRIPTION
With the latest ZITADEL version, the probes (startup, liveness and readiness probes) do not work any more, possibly due to this commit https://github.com/zitadel/zitadel/commit/4c879b47334e01d4fcab921ac1b44eda39acdb96. Adding the HOST header to these probes make them work again.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
