### PR TITLE
fix: use fully qualified image names for wait4x init containers

### DIFF
--- a/charts/zitadel/templates/deployment_login.yaml
+++ b/charts/zitadel/templates/deployment_login.yaml
@@ -113,7 +113,7 @@ spec:
         # OK status. The `--insecure-skip-tls-verify` flag is included to support
         # environments that use self-signed certificates for internal TLS.
         - name: wait-for-zitadel
-          image: wait4x/wait4x:3.6
+          image: {{ .Values.wait4x.image.repository }}:{{ .Values.wait4x.image.tag }}
           command:
             - wait4x
             - http

--- a/charts/zitadel/templates/deployment_zitadel.yaml
+++ b/charts/zitadel/templates/deployment_zitadel.yaml
@@ -226,7 +226,7 @@ spec:
         # the main ZITADEL container from starting and potentially crashing before its
         # database is available, thus improving deployment reliability.
         - name: wait-for-postgres
-          image: wait4x/wait4x:3.6
+          image: {{ .Values.wait4x.image.repository }}:{{ .Values.wait4x.image.tag }}
           command:
             - wait4x
             - tcp

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -1,4 +1,15 @@
 # Default values for zitadel.
+
+# Configuration for the wait4x init container image used to check dependencies
+# before starting the main containers. This image is used in both the ZITADEL
+# and Login deployments to wait for PostgreSQL and the ZITADEL API respectively.
+# Using fully qualified image names (with registry prefix) is required for
+# Kubernetes clusters using CRI-O v1.34+ which enforces this format.
+wait4x:
+  image:
+    repository: docker.io/wait4x/wait4x
+    tag: "3.6"
+
 zitadel:
   # The ZITADEL config under configmapConfig is written to a Kubernetes ConfigMap
   # See all defaults here:
@@ -252,6 +263,15 @@ login:
   # ZITADEL_SERVICE_USER_TOKEN_FILE="/login-client/pat"
   # ZITADEL_API_URL="http://{{ include "zitadel.fullname" . }}:{{ .Values.service.port }}"
   # CUSTOM_REQUEST_HEADERS="Host:{{ .Values.zitadel.configmapConfig.ExternalDomain }}"
+  #
+  # IMPORTANT: For ZITADEL v4.7.1+ with stricter origin validation (GHSA-7wfc-4796-gmg5),
+  # you may need to add X-Zitadel-Public-Host to CUSTOM_REQUEST_HEADERS to avoid
+  # "public domain not trusted" errors. See https://github.com/zitadel/zitadel/issues/11163
+  # Example:
+  # customConfigmapConfig: |
+  #   ZITADEL_SERVICE_USER_TOKEN_FILE="/login-client/pat"
+  #   ZITADEL_API_URL="http://zitadel:8080"
+  #   CUSTOM_REQUEST_HEADERS="Host:your.domain.com,X-Zitadel-Public-Host:your.domain.com"
   customConfigmapConfig:
   # To deploy zitadel multiple times in the same namespace, use a loginClientSecretPrefix.
   # To mount it, also change the referenced secretName for the login client to "{loginClientSecretPrefix}login-client"


### PR DESCRIPTION
## Summary

- Make wait4x image configurable via `values.yaml` (`wait4x.image.repository`/`tag`)
- Default to `docker.io/wait4x/wait4x:3.6` (fully qualified)
- Document `X-Zitadel-Public-Host` workaround for v4.7.1+ origin validation issues

## Problem

Kubernetes clusters using CRI-O v1.34+ enforce fully qualified image names. Without this change, pods fail with:

```
Init:Failed to inspect image "": rpc error: code = Unknown desc = short name mode is enforcing, but image name wait4x/wait4x:3.6 returns ambiguous list
```

Additionally, users upgrading to ZITADEL v4.7.1+ encounter "public domain not trusted" errors due to stricter origin validation introduced by the GHSA-7wfc-4796-gmg5 security fix. The workaround (adding `X-Zitadel-Public-Host` header) is now documented in `values.yaml`.

## Changes

1. **New `wait4x` configuration block** in `values.yaml`:
   ```yaml
   wait4x:
     image:
       repository: docker.io/wait4x/wait4x
       tag: "3.6"
   ```

2. **Updated templates** to use configurable image:
   - `templates/deployment_zitadel.yaml`
   - `templates/deployment_login.yaml`

3. **Documentation** for `customConfigmapConfig` explaining the `X-Zitadel-Public-Host` workaround

## Testing

```bash
helm template test charts/zitadel \
  --set zitadel.masterkey=testtesttesttesttesttesttesttest \
  --set zitadel.configmapConfig.ExternalDomain=test.example.com \
  --set zitadel.configmapConfig.Database.Postgres.Host=postgres \
  | grep -A2 "wait-for"
```

Output confirms fully qualified image names:
```yaml
- name: wait-for-postgres
  image: docker.io/wait4x/wait4x:3.6
- name: wait-for-zitadel
  image: docker.io/wait4x/wait4x:3.6
```

## Related Issues

- Fixes #492
- Related: #494, zitadel/zitadel#11163