### PR TITLE
fix: align pod and container security contexts with global defaults

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: v4.2.0
-version: 9.16.0
+version: 9.16.1
 kubeVersion: '>= 1.30.0-0'
 icon: https://zitadel.com/zitadel-logo-dark.svg
 maintainers:

--- a/charts/zitadel/smoke_test/security_context_test.go
+++ b/charts/zitadel/smoke_test/security_context_test.go
@@ -1,0 +1,244 @@
+package smoke_test_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/zitadel/zitadel-charts/charts/zitadel/smoke_test/support"
+)
+
+type securityContextsExpected struct {
+	zitadelPodSecurityContext *corev1.PodSecurityContext
+	zitadelSecurityContext    *corev1.SecurityContext
+	loginPodSecurityContext   *corev1.PodSecurityContext
+	loginSecurityContext      *corev1.SecurityContext
+}
+
+func TestSecurityContexts(t *testing.T) {
+	t.Parallel()
+
+	cluster := support.ConnectCluster(t)
+
+	chartPath, err := filepath.Abs("..")
+	require.NoError(t, err)
+
+	int64Ptr := func(value int64) *int64 { return &value }
+	boolPtr := func(value bool) *bool { return &value }
+
+	testCases := []struct {
+		name      string
+		setValues map[string]string
+		expected  securityContextsExpected
+	}{
+		{
+			name: "defaults-use-global",
+			setValues: map[string]string{
+				"login.enabled":         "true",
+				"login.ingress.enabled": "true",
+			},
+			expected: securityContextsExpected{
+				zitadelPodSecurityContext: &corev1.PodSecurityContext{
+					RunAsNonRoot: boolPtr(true),
+					RunAsUser:    int64Ptr(1000),
+					FSGroup:      int64Ptr(1000),
+				},
+				zitadelSecurityContext: &corev1.SecurityContext{
+					RunAsNonRoot:             boolPtr(true),
+					RunAsUser:                int64Ptr(1000),
+					ReadOnlyRootFilesystem:   boolPtr(true),
+					Privileged:               boolPtr(false),
+					AllowPrivilegeEscalation: nil,
+					Capabilities:             nil,
+				},
+				loginPodSecurityContext: &corev1.PodSecurityContext{
+					RunAsNonRoot: boolPtr(true),
+					RunAsUser:    int64Ptr(1000),
+					FSGroup:      int64Ptr(1000),
+				},
+				loginSecurityContext: &corev1.SecurityContext{
+					RunAsNonRoot:             boolPtr(true),
+					RunAsUser:                int64Ptr(1000),
+					ReadOnlyRootFilesystem:   boolPtr(true),
+					Privileged:               boolPtr(false),
+					AllowPrivilegeEscalation: nil,
+					Capabilities:             nil,
+				},
+			},
+		},
+		{
+			name: "component-overrides",
+			setValues: map[string]string{
+				"login.enabled":         "true",
+				"login.ingress.enabled": "true",
+
+				"zitadel.podSecurityContext.runAsNonRoot":          "true",
+				"zitadel.podSecurityContext.runAsUser":             "2000",
+				"zitadel.podSecurityContext.fsGroup":               "2000",
+				"zitadel.podSecurityContext.seccompProfile.type":   "RuntimeDefault",
+				"zitadel.securityContext.runAsNonRoot":             "true",
+				"zitadel.securityContext.runAsUser":                "2000",
+				"zitadel.securityContext.readOnlyRootFilesystem":   "true",
+				"zitadel.securityContext.privileged":               "false",
+				"zitadel.securityContext.allowPrivilegeEscalation": "false",
+				"zitadel.securityContext.capabilities.drop[0]":     "ALL",
+				"login.podSecurityContext.runAsNonRoot":            "true",
+				"login.podSecurityContext.runAsUser":               "3000",
+				"login.podSecurityContext.fsGroup":                 "3000",
+				"login.podSecurityContext.seccompProfile.type":     "RuntimeDefault",
+				"login.securityContext.runAsNonRoot":               "true",
+				"login.securityContext.runAsUser":                  "3000",
+				"login.securityContext.readOnlyRootFilesystem":     "true",
+				"login.securityContext.privileged":                 "false",
+				"login.securityContext.allowPrivilegeEscalation":   "false",
+				"login.securityContext.capabilities.drop[0]":       "NET_RAW",
+			},
+			expected: securityContextsExpected{
+				zitadelPodSecurityContext: &corev1.PodSecurityContext{
+					RunAsNonRoot: boolPtr(true),
+					RunAsUser:    int64Ptr(2000),
+					FSGroup:      int64Ptr(2000),
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
+				zitadelSecurityContext: &corev1.SecurityContext{
+					RunAsNonRoot:             boolPtr(true),
+					RunAsUser:                int64Ptr(2000),
+					ReadOnlyRootFilesystem:   boolPtr(true),
+					Privileged:               boolPtr(false),
+					AllowPrivilegeEscalation: boolPtr(false),
+					Capabilities: &corev1.Capabilities{
+						Drop: []corev1.Capability{"ALL"},
+					},
+				},
+				loginPodSecurityContext: &corev1.PodSecurityContext{
+					RunAsNonRoot: boolPtr(true),
+					RunAsUser:    int64Ptr(3000),
+					FSGroup:      int64Ptr(3000),
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
+				loginSecurityContext: &corev1.SecurityContext{
+					RunAsNonRoot:             boolPtr(true),
+					RunAsUser:                int64Ptr(3000),
+					ReadOnlyRootFilesystem:   boolPtr(true),
+					Privileged:               boolPtr(false),
+					AllowPrivilegeEscalation: boolPtr(false),
+					Capabilities: &corev1.Capabilities{
+						Drop: []corev1.Capability{"NET_RAW"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			support.WithNamespace(t, cluster, func(env *support.Env) {
+				env.Logger.Logf(t, "namespace %q created; installing PostgreSQL…", env.Namespace)
+				support.WithPostgres(t, env)
+
+				uniqueDomain := fmt.Sprintf("%s.test.local", env.Namespace)
+				commonSetValues := map[string]string{
+					"zitadel.masterkey":                                         "x123456789012345678901234567891y",
+					"zitadel.configmapConfig.ExternalDomain":                    uniqueDomain,
+					"zitadel.configmapConfig.ExternalPort":                      "443",
+					"zitadel.configmapConfig.TLS.Enabled":                       "false",
+					"zitadel.configmapConfig.Database.Postgres.Host":            "db-postgresql",
+					"zitadel.configmapConfig.Database.Postgres.Port":            "5432",
+					"zitadel.configmapConfig.Database.Postgres.Database":        "zitadel",
+					"zitadel.configmapConfig.Database.Postgres.MaxOpenConns":    "20",
+					"zitadel.configmapConfig.Database.Postgres.MaxIdleConns":    "10",
+					"zitadel.configmapConfig.Database.Postgres.MaxConnLifetime": "30m",
+					"zitadel.configmapConfig.Database.Postgres.MaxConnIdleTime": "5m",
+					"zitadel.configmapConfig.Database.Postgres.User.Username":   "postgres",
+					"zitadel.configmapConfig.Database.Postgres.User.SSL.Mode":   "disable",
+					"zitadel.configmapConfig.Database.Postgres.Admin.Username":  "postgres",
+					"zitadel.configmapConfig.Database.Postgres.Admin.SSL.Mode":  "disable",
+					"ingress.enabled":       "true",
+					"login.ingress.enabled": "true",
+				}
+
+				releaseName := env.MakeRelease("zitadel-test", testCase.name)
+
+				mergedSetValues := make(map[string]string)
+				for key, value := range commonSetValues {
+					mergedSetValues[key] = value
+				}
+				for key, value := range testCase.setValues {
+					mergedSetValues[key] = value
+				}
+
+				helmOptions := &helm.Options{
+					KubectlOptions: env.Kube,
+					SetValues:      mergedSetValues,
+					ExtraArgs: map[string][]string{
+						"upgrade": {"--install", "--wait", "--timeout", "30m"},
+					},
+				}
+
+				if err := helm.UpgradeE(t, helmOptions, chartPath, releaseName); err != nil {
+					dumpSetupAndInitJobLogs(t, env, releaseName)
+					require.NoError(t, err)
+				}
+
+				ctx := context.Background()
+
+				zitadelDeployment, err := env.Client.
+					AppsV1().
+					Deployments(env.Kube.Namespace).
+					Get(ctx, releaseName, metav1.GetOptions{})
+				require.NoError(t, err, "failed to get zitadel deployment")
+				assertDeploymentSecurity(t, zitadelDeployment, testCase.expected.zitadelPodSecurityContext, testCase.expected.zitadelSecurityContext, "zitadel")
+
+				loginDeployment, err := env.Client.
+					AppsV1().
+					Deployments(env.Kube.Namespace).
+					Get(ctx, releaseName+"-login", metav1.GetOptions{})
+				require.NoError(t, err, "failed to get login deployment")
+				assertDeploymentSecurity(t, loginDeployment, testCase.expected.loginPodSecurityContext, testCase.expected.loginSecurityContext, "zitadel-login")
+			})
+		})
+	}
+}
+
+func assertDeploymentSecurity(t *testing.T, deployment *appsv1.Deployment, expectedPodSC *corev1.PodSecurityContext, expectedContainerSC *corev1.SecurityContext, containerName string) {
+	t.Helper()
+
+	require.NotNil(t, deployment.Spec.Template.Spec.SecurityContext, "pod securityContext missing for deployment %s", deployment.Name)
+	require.Equal(t, expectedPodSC, deployment.Spec.Template.Spec.SecurityContext, "pod securityContext mismatch for deployment %s", deployment.Name)
+
+	container := findContainer(deployment.Spec.Template.Spec.Containers, containerName)
+	require.NotNil(t, container, "container %s not found in deployment %s", containerName, deployment.Name)
+	require.NotNil(t, container.SecurityContext, "container securityContext missing for %s", containerName)
+	require.Equal(t, expectedContainerSC, container.SecurityContext, "container securityContext mismatch for %s", containerName)
+
+	for _, c := range deployment.Spec.Template.Spec.InitContainers {
+		require.NotNil(t, c.SecurityContext, "init container securityContext missing for %s in deployment %s", c.Name, deployment.Name)
+		require.Equal(t, expectedContainerSC, c.SecurityContext, "init container securityContext mismatch for %s in deployment %s", c.Name, deployment.Name)
+	}
+	for _, c := range deployment.Spec.Template.Spec.Containers {
+		require.NotNil(t, c.SecurityContext, "container securityContext missing for %s in deployment %s", c.Name, deployment.Name)
+		require.Equal(t, expectedContainerSC, c.SecurityContext, "container securityContext mismatch for %s in deployment %s", c.Name, deployment.Name)
+	}
+}
+
+func findContainer(containers []corev1.Container, name string) *corev1.Container {
+	for i := range containers {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
+	return nil
+}

--- a/charts/zitadel/templates/_helpers.tpl
+++ b/charts/zitadel/templates/_helpers.tpl
@@ -206,6 +206,54 @@ Create the name of the login service account to use
 {{- end }}
 
 {{/*
+Return the pod security context for Zitadel workloads.
+Prefers zitadel.podSecurityContext; falls back to the chart-wide podSecurityContext.
+*/}}
+{{- define "zitadel.podSecurityContext" -}}
+{{- if .Values.zitadel.podSecurityContext }}
+{{- toYaml .Values.zitadel.podSecurityContext -}}
+{{- else }}
+{{- toYaml (default (dict) .Values.podSecurityContext) -}}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the container security context for Zitadel workloads.
+Prefers zitadel.securityContext; falls back to the chart-wide securityContext.
+*/}}
+{{- define "zitadel.securityContext" -}}
+{{- if .Values.zitadel.securityContext }}
+{{- toYaml .Values.zitadel.securityContext -}}
+{{- else }}
+{{- toYaml (default (dict) .Values.securityContext) -}}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the pod security context for Login workloads.
+Prefers login.podSecurityContext; falls back to the chart-wide podSecurityContext.
+*/}}
+{{- define "login.podSecurityContext" -}}
+{{- if .Values.login.podSecurityContext }}
+{{- toYaml .Values.login.podSecurityContext -}}
+{{- else }}
+{{- toYaml (default (dict) .Values.podSecurityContext) -}}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the container security context for Login workloads.
+Prefers login.securityContext; falls back to the chart-wide securityContext.
+*/}}
+{{- define "login.securityContext" -}}
+{{- if .Values.login.securityContext }}
+{{- toYaml .Values.login.securityContext -}}
+{{- else }}
+{{- toYaml (default (dict) .Values.securityContext) -}}
+{{- end }}
+{{- end }}
+
+{{/*
 Returns the database config from the secretConfig or else from the configmapConfig
 */}}
 {{- define "zitadel.dbconfig.json" -}}

--- a/charts/zitadel/templates/deployment_login.yaml
+++ b/charts/zitadel/templates/deployment_login.yaml
@@ -38,7 +38,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "login.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.login.podSecurityContext | nindent 8 }}
+        {{- include "login.podSecurityContext" . | nindent 8 }}
       enableServiceLinks: false
       containers:
       {{- if .Values.login.extraContainers }}
@@ -46,7 +46,7 @@ spec:
       {{- end }}
         - name: {{ .Chart.Name }}-login
           securityContext:
-            {{- toYaml .Values.login.securityContext | nindent 14 }}
+            {{- include "login.securityContext" . | nindent 14 }}
           image: "{{ .Values.login.image.repository }}:{{ .Values.login.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.login.image.pullPolicy }}
           env:
@@ -129,7 +129,7 @@ spec:
             - --interval
             - "5s"
           securityContext:
-            {{- toYaml .Values.login.securityContext | nindent 12 }}
+            {{- include "login.securityContext" . | nindent 12 }}
       {{- with .Values.login.initContainers }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/zitadel/templates/deployment_zitadel.yaml
+++ b/charts/zitadel/templates/deployment_zitadel.yaml
@@ -44,7 +44,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "zitadel.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- include "zitadel.podSecurityContext" . | nindent 8 }}
       enableServiceLinks: false
       containers:
       {{- if .Values.zitadel.extraContainers }}
@@ -55,7 +55,7 @@ spec:
       {{- end }}
         - name: {{ .Chart.Name }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 14 }}
+            {{- include "zitadel.securityContext" . | nindent 14 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
@@ -237,7 +237,7 @@ spec:
             - --interval
             - "5s"
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- include "zitadel.securityContext" . | nindent 12 }}
       {{- end }}
       {{- with .Values.zitadel.initContainers }}
         {{- toYaml . | nindent 8 }}

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -94,6 +94,11 @@ zitadel:
   # Set to 0 to not keep any old ReplicaSets
   revisionHistoryLimit: 10
 
+  # Optional overrides for the pod and container security contexts used by Zitadel pods.
+  # If left empty, the chart-wide podSecurityContext and securityContext defined below are used.
+  podSecurityContext: {}
+  securityContext: {}
+
   # Horizontal Pod Autoscaler configuration for scaling on CPU, memory, or custom metrics.
   # Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
   autoscaling:
@@ -340,15 +345,10 @@ login:
     # The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template
     name: ""
-  podSecurityContext:
-    runAsNonRoot: true
-    runAsUser: 1000
-    fsGroup: 1000
-  securityContext:
-    runAsNonRoot: true
-    runAsUser: 1000
-    readOnlyRootFilesystem: true
-    privileged: false
+  # Optional overrides for the pod and container security contexts used by the login pods.
+  # If left empty, the chart-wide podSecurityContext and securityContext defined below are used.
+  podSecurityContext: {}
+  securityContext: {}
   resources: {}
   nodeSelector: {}
   tolerations: []
@@ -432,11 +432,15 @@ podAnnotations: {}
 
 podAdditionalLabels: {}
 
+# Chart-wide pod security context. Applied to all pods by default, unless
+# overridden by zitadel.podSecurityContext or login.podSecurityContext.
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 1000
   fsGroup: 1000
 
+# Chart-wide container security context. Applied to all containers by default,
+# unless overridden by zitadel.securityContext or login.securityContext.
 securityContext:
   runAsNonRoot: true
   runAsUser: 1000


### PR DESCRIPTION
This poull-reqest aligns Zitadel and Login container security contexts with the global defaults while allowing component-level overrides and adds coverage to ensure every chart-rendered container and init container keeps a securityContext. The chart now prefers zitadel.podSecurityContext/securityContext and login.podSecurityContext/securityContext when set, otherwise falls back to the chart-wide podSecurityContext and securityContext. Documentation clarifies the fallback behavior, and a new smoke test validates pod and container security contexts (including init containers) on both deployments. Acceptance/smoke tests still require a reachable Kubernetes cluster to run.

**Examples:**

Use only global defaults:

  ```
  podSecurityContext:
    runAsNonRoot: true
    runAsUser: 1000
    fsGroup: 1000
  securityContext:
    runAsNonRoot: true
    runAsUser: 1000
    readOnlyRootFilesystem: true
    privileged: false
  login:
    enabled: true
    ingress:
      enabled: true
  ```
- Override Zitadel and Login independently, falling back to globals for other containers:
  ```
  podSecurityContext:
    runAsNonRoot: true
    runAsUser: 1000
    fsGroup: 1000
  securityContext:
    runAsNonRoot: true
    runAsUser: 1000
    readOnlyRootFilesystem: true
    privileged: false
  zitadel:
    podSecurityContext:
      seccompProfile:
        type: RuntimeDefault
      runAsUser: 2000
      fsGroup: 2000
    securityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
          - ALL
      runAsUser: 2000
  login:
    enabled: true
    ingress:
      enabled: true
    podSecurityContext:
      seccompProfile:
        type: RuntimeDefault
      runAsUser: 3000
      fsGroup: 3000
    securityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
          - NET_RAW
      runAsUser: 3000
  ```


### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
