### PR TITLE
Pr-556

### DIFF
--- a/charts/zitadel/README.md
+++ b/charts/zitadel/README.md
@@ -63,6 +63,18 @@ To actually use the new login, enable the loginV2 feature on the instance.
 Leave the base URI empty to use the default or explicitly configure it to `/ui/v2/login`.
 If you enable this feature, the login will be used for every application configured in your Zitadel instance.
 
+### NGINX Ingress: Set `ingress.controller: nginx` (v9.24.0 → v9.25.0)
+
+Prior to v9.25.0, the `nginx.ingress.kubernetes.io/backend-protocol: GRPC` annotation was included in the default `ingress.annotations` map, so it was applied regardless of the ingress controller in use.
+Starting with v9.25.0, the annotation is only injected when `ingress.controller` is explicitly set to `nginx`.
+
+If you are using the NGINX ingress controller, add the following to your values before upgrading:
+
+```yaml
+ingress:
+  controller: nginx
+```
+
 ### Other Breaking Changes
 
 - Default Traefik and NGINX annotations for internal unencrypted HTTP/2 traffic to the Zitadel pods are added.

--- a/charts/zitadel/README.md.gotmpl
+++ b/charts/zitadel/README.md.gotmpl
@@ -63,6 +63,18 @@ To actually use the new login, enable the loginV2 feature on the instance.
 Leave the base URI empty to use the default or explicitly configure it to `/ui/v2/login`.
 If you enable this feature, the login will be used for every application configured in your Zitadel instance.
 
+### NGINX Ingress: Set `ingress.controller: nginx` (v9.24.0 → v9.25.0)
+
+Prior to v9.25.0, the `nginx.ingress.kubernetes.io/backend-protocol: GRPC` annotation was included in the default `ingress.annotations` map, so it was applied regardless of the ingress controller in use.
+Starting with v9.25.0, the annotation is only injected when `ingress.controller` is explicitly set to `nginx`.
+
+If you are using the NGINX ingress controller, add the following to your values before upgrading:
+
+```yaml
+ingress:
+  controller: nginx
+```
+
 ### Other Breaking Changes
 
 - Default Traefik and NGINX annotations for internal unencrypted HTTP/2 traffic to the Zitadel pods are added.

--- a/charts/zitadel/templates/ingress_zitadel.yaml
+++ b/charts/zitadel/templates/ingress_zitadel.yaml
@@ -8,6 +8,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "zitadel.labels" . | nindent 4 }}
+  {{- $hasAnnotations := or (eq .Values.ingress.controller "aws") (eq .Values.ingress.controller "nginx") (gt (len .Values.ingress.annotations) 0) }}
+  {{- if $hasAnnotations }}
   annotations:
     {{- if eq .Values.ingress.controller "aws" }}
     alb.ingress.kubernetes.io/group.order: '-1' # to not conflict with zitadel-login
@@ -20,6 +22,7 @@ metadata:
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
   {{- with .Values.ingress.tls }}


### PR DESCRIPTION
- Wrap the annotations block in ingress_zitadel.yaml with a conditional so the key is omitted entirely when no annotations apply (controller=generic, empty annotations map), avoiding a
  rendered 'annotations: null' key.
- Add an upgrade note to README.md.gotmpl documenting the breaking change for nginx ingress users upgrading from v9.24.0, instructing them to set ingress.controller: nginx.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
