### PR TITLE
fix(postgres): [example 1-postgres-insecure] Update pgHbaConfiguration to allow local connections

### DIFF
--- a/examples/1-postgres-insecure/postgres-values.yaml
+++ b/examples/1-postgres-insecure/postgres-values.yaml
@@ -13,4 +13,5 @@ primary:
   persistence:
     enabled: false
   pgHbaConfiguration: |
+    local all all trust
     host all all all trust


### PR DESCRIPTION
The values file for postgres only defined the following content for `pg_hba.conf`:

```
  host all all all trust
```

While this is valid PostgreSQL syntax, it removes the `local` rule required by the Bitnami PostgreSQL initialization scripts to connect via the Unix socket during setup.

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes

Logs:

```shell
➜  $ helm install db bitnami/postgresql --version 12.10.0 --values https://raw.githubusercontent.com/zitadel/zitadel-charts/main/examples/1-postgres-insecure/postgres-values.yaml

NAME: db
LAST DEPLOYED: Thu Mar  5 11:58:09 2026
NAMESPACE: default
STATUS: deployed
REVISION: 1
DESCRIPTION: Install complete
TEST SUITE: None
NOTES:
CHART NAME: postgresql
CHART VERSION: 12.10.0
APP VERSION: 15.4.0

** Please be patient while the chart is being deployed **

PostgreSQL can be accessed via port 5432 on the following DNS names from within your cluster:

    db-postgresql.default.svc.cluster.local - Read/Write connection

To get the password for "postgres" run:

    export POSTGRES_PASSWORD=$(kubectl get secret --namespace default db-postgresql -o jsonpath="{.data.postgres-password}" | base64 -d)

To connect to your database run the following command:

    kubectl run db-postgresql-client --rm --tty -i --restart='Never' --namespace default --image docker.io/bitnamilegacy/postgresql:15.4.0-debian-11-r10 --env="PGPASSWORD=$POSTGRES_PASSWORD" \
      --command -- psql --host db-postgresql -U postgres -d postgres -p 5432

    > NOTE: If you access the container using bash, make sure that you execute "/opt/bitnami/scripts/postgresql/entrypoint.sh /bin/bash" in order to avoid the error "psql: local user with ID 1001} does not exist"

To connect to your database from outside the cluster execute the following commands:

    kubectl port-forward --namespace default svc/db-postgresql 5432:5432 &
    PGPASSWORD="$POSTGRES_PASSWORD" psql --host 127.0.0.1 -U postgres -d postgres -p 5432

WARNING: The configured password will be ignored on new installation in case when previous PostgreSQL release was deleted through the helm command. In that case, old PVC will have an old password, and setting it through helm won't take effect. Deleting persistent volumes (PVs) will solve the issue.


➜  $ k logs db-postgresql-0
postgresql 10:58:11.06
postgresql 10:58:11.07 Welcome to the Bitnami postgresql container
postgresql 10:58:11.07 Subscribe to project updates by watching https://github.com/bitnami/containers
postgresql 10:58:11.07 Submit issues and feature requests at https://github.com/bitnami/containers/issues
postgresql 10:58:11.07
postgresql 10:58:11.07 INFO  ==> ** Starting PostgreSQL setup **
postgresql 10:58:11.08 INFO  ==> Validating settings in POSTGRESQL_* env vars..
postgresql 10:58:11.08 INFO  ==> Loading custom pre-init scripts...
postgresql 10:58:11.08 INFO  ==> Initializing PostgreSQL database...
postgresql 10:58:11.09 INFO  ==> Custom configuration /opt/bitnami/postgresql/conf/pg_hba.conf detected
postgresql 10:58:11.30 INFO  ==> Starting PostgreSQL in background...
postgresql 10:58:11.41 INFO  ==> Changing password of postgres
postgresql 10:58:11.42 INFO  ==> Stopping PostgreSQL...
waiting for server to shut down.... done
server stopped


➜  $ k get cm db-postgresql-configuration -o yaml
apiVersion: v1
data:
  pg_hba.conf: |
    host all all all trust
kind: ConfigMap
metadata:
  annotations:
    meta.helm.sh/release-name: db
    meta.helm.sh/release-namespace: default
  creationTimestamp: "2026-03-05T10:58:09Z"
  labels:
    app.kubernetes.io/component: primary
    app.kubernetes.io/instance: db
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: postgresql
    helm.sh/chart: postgresql-12.10.0
  name: db-postgresql-configuration
  namespace: default
  resourceVersion: "5245"
  uid: cc10444d-7cca-4f45-803e-7861dbadde21


➜  $ k patch configmap db-postgresql-configuration \
  --type merge \
  -p '{"data":{"pg_hba.conf":"local all all trust\nhost all all all trust\n"}}'
configmap/db-postgresql-configuration patched


➜  $ k get cm db-postgresql-configuration -o yaml
apiVersion: v1
data:
  pg_hba.conf: |
    local all all trust
    host all all all trust
kind: ConfigMap
metadata:
  annotations:
    meta.helm.sh/release-name: db
    meta.helm.sh/release-namespace: default
  creationTimestamp: "2026-03-05T10:58:09Z"
  labels:
    app.kubernetes.io/component: primary
    app.kubernetes.io/instance: db
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: postgresql
    helm.sh/chart: postgresql-12.10.0
  name: db-postgresql-configuration
  namespace: default
  resourceVersion: "5524"
  uid: cc10444d-7cca-4f45-803e-7861dbadde21

➜  /tmp k rollout restart statefulset db-postgresql
statefulset.apps/db-postgresql restarted

➜  $ k logs db-postgresql-0
postgresql 11:01:27.20
postgresql 11:01:27.20 Welcome to the Bitnami postgresql container
postgresql 11:01:27.20 Subscribe to project updates by watching https://github.com/bitnami/containers
postgresql 11:01:27.20 Submit issues and feature requests at https://github.com/bitnami/containers/issues
postgresql 11:01:27.20
postgresql 11:01:27.21 INFO  ==> ** Starting PostgreSQL setup **
postgresql 11:01:27.22 INFO  ==> Validating settings in POSTGRESQL_* env vars..
postgresql 11:01:27.22 INFO  ==> Loading custom pre-init scripts...
postgresql 11:01:27.22 INFO  ==> Initializing PostgreSQL database...
postgresql 11:01:27.22 INFO  ==> Custom configuration /opt/bitnami/postgresql/conf/pg_hba.conf detected
postgresql 11:01:27.47 INFO  ==> Starting PostgreSQL in background...
postgresql 11:01:27.58 INFO  ==> Changing password of postgres
postgresql 11:01:27.59 INFO  ==> Configuring replication parameters
postgresql 11:01:27.60 INFO  ==> Configuring fsync
postgresql 11:01:27.61 INFO  ==> Stopping PostgreSQL...
waiting for server to shut down.... done
server stopped
postgresql 11:01:27.72 INFO  ==> Loading custom scripts...
postgresql 11:01:27.72 INFO  ==> Enabling remote connections

postgresql 11:01:27.72 INFO  ==> ** PostgreSQL setup finished! **
postgresql 11:01:27.73 INFO  ==> ** Starting PostgreSQL **
2026-03-05 11:01:27.739 GMT [1] LOG:  pgaudit extension initialized
2026-03-05 11:01:27.743 GMT [1] LOG:  starting PostgreSQL 15.4 on aarch64-unknown-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
2026-03-05 11:01:27.743 GMT [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
2026-03-05 11:01:27.743 GMT [1] LOG:  listening on IPv6 address "::", port 5432
2026-03-05 11:01:27.744 GMT [1] LOG:  listening on Unix socket "/tmp/.s.PGSQL.5432"
2026-03-05 11:01:27.746 GMT [128] LOG:  database system was shut down at 2026-03-05 11:01:27 GMT
2026-03-05 11:01:27.748 GMT [1] LOG:  database system is ready to accept connections
```