### PR TITLE
fix: make appProtocol conditional to support Gateway API (#580)

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: v4.13.0
-version: 9.28.0
+version: 9.29.0
 kubeVersion: '>= 1.30.0-0'
 home: https://zitadel.com
 sources:

--- a/charts/zitadel/README.md
+++ b/charts/zitadel/README.md
@@ -2,7 +2,7 @@
 
 # Zitadel
 
-![Version: 9.28.0](https://img.shields.io/badge/Version-9.28.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.13.0](https://img.shields.io/badge/AppVersion-v4.13.0-informational?style=flat-square)
+![Version: 9.29.0](https://img.shields.io/badge/Version-9.29.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.13.0](https://img.shields.io/badge/AppVersion-v4.13.0-informational?style=flat-square)
 
 ## A Better Identity and Access Management Solution
 

--- a/charts/zitadel/templates/service_login.yaml
+++ b/charts/zitadel/templates/service_login.yaml
@@ -31,7 +31,9 @@ spec:
       targetPort: {{ include "login.containerPort" . }}
       protocol: TCP
       name: {{ regexReplaceAll "\\W+" .Values.login.service.protocol "-" }}-server
-      appProtocol: {{ .Values.login.service.appProtocol }}
+      {{- with .Values.login.service.appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
     {{- if .Values.login.metrics.enabled }}
     - port: 9464
       targetPort: 9464

--- a/charts/zitadel/templates/service_zitadel-grpc.yaml
+++ b/charts/zitadel/templates/service_zitadel-grpc.yaml
@@ -31,7 +31,9 @@ spec:
       targetPort: {{ include "zitadel.containerPort" . }}
       protocol: TCP
       name: {{ regexReplaceAll "\\W+" .Values.service.protocol "-" }}-server
-      appProtocol: {{ .Values.service.appProtocol }}
+      {{- with .Values.service.appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
   selector:
     {{- include "zitadel.start.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/zitadel/templates/service_zitadel.yaml
+++ b/charts/zitadel/templates/service_zitadel.yaml
@@ -30,6 +30,8 @@ spec:
       targetPort: {{ include "zitadel.containerPort" . }}
       protocol: TCP
       name: {{ regexReplaceAll "\\W+" .Values.service.protocol "-" }}-server
-      appProtocol: {{ .Values.service.appProtocol }}
+      {{- with .Values.service.appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
   selector:
     {{- include "zitadel.start.selectorLabels" . | nindent 4 }}

--- a/test/acceptance/main_test.go
+++ b/test/acceptance/main_test.go
@@ -5,8 +5,9 @@
 // A K3s cluster is started automatically via testcontainers before any test
 // runs. K3s ships with a bundled Traefik ingress controller which is customized
 // via a HelmChartConfig manifest to use NodePort with dynamically mapped ports.
-// The cluster is torn down when the suite completes. No external cluster or
-// manual setup is required.
+// The Gateway API provider is enabled and Traefik creates a GatewayClass and
+// Gateway automatically. The cluster is torn down when the suite completes.
+// No external cluster or manual setup is required.
 package acceptance_test
 
 import (
@@ -26,12 +27,17 @@ const k3sStartupTimeout = 5 * time.Minute
 // to construct API base URLs and configure ZITADEL's ExternalPort.
 var httpsPort string
 
+// httpPort holds the dynamically mapped host port for the Traefik HTTP
+// NodePort (30080). It is used by Gateway API tests where traffic flows
+// through the "web" entrypoint without TLS.
+var httpPort string
+
 func TestMain(m *testing.M) {
 	os.Exit(run(m))
 }
 
 // run starts a K3s cluster with its bundled Traefik ingress controller,
-// extracts the kubeconfig, discovers the dynamically mapped HTTPS port, and
+// extracts the kubeconfig, discovers the dynamically mapped ports, and
 // then executes the test suite. It returns the exit code from m.Run.
 func run(m *testing.M) int {
 	ctx, cancel := context.WithTimeout(context.Background(), k3sStartupTimeout)
@@ -45,6 +51,7 @@ func run(m *testing.M) int {
 	defer cluster.Cleanup()
 
 	httpsPort = cluster.HTTPSPort
+	httpPort = cluster.HTTPPort
 
 	return m.Run()
 }

--- a/test/acceptance/zitadel.go
+++ b/test/acceptance/zitadel.go
@@ -21,8 +21,10 @@ type ZitadelOption func(*zitadelConfig)
 type zitadelConfig struct {
 	externalDomain      string
 	externalPort        string
+	externalSecure      *bool
 	tlsEnabled          bool
 	selfSignedCert      bool
+	useGateway          bool
 	masterkeySecretName string
 	configSecretName    string
 	configSecretKey     string
@@ -124,6 +126,38 @@ func WithoutDBHost() ZitadelOption {
 	}
 }
 
+// WithGateway configures ZITADEL to use Gateway API HTTPRoute and GRPCRoute
+// instead of Ingress. This disables Ingress, enables HTTPRoute and GRPCRoute
+// for ZITADEL and HTTPRoute for Login, with parentRefs pointing to the
+// specified Gateway. It also clears appProtocol on all services so that the
+// Gateway controller infers the backend protocol from the route type.
+func WithGateway(gatewayName, gatewayNamespace string) ZitadelOption {
+	return func(c *zitadelConfig) {
+		c.useGateway = true
+		c.additionalValues["service.appProtocol"] = ""
+		c.additionalValues["login.service.appProtocol"] = ""
+		c.additionalValues["gateway.httpRoute.enabled"] = "true"
+		c.additionalValues["gateway.httpRoute.parentRefs[0].name"] = gatewayName
+		c.additionalValues["gateway.httpRoute.parentRefs[0].namespace"] = gatewayNamespace
+		c.additionalValues["gateway.httpRoute.parentRefs[0].sectionName"] = "web"
+		c.additionalValues["gateway.grpcRoute.enabled"] = "true"
+		c.additionalValues["gateway.grpcRoute.parentRefs[0].name"] = gatewayName
+		c.additionalValues["gateway.grpcRoute.parentRefs[0].namespace"] = gatewayNamespace
+		c.additionalValues["gateway.grpcRoute.parentRefs[0].sectionName"] = "web"
+		c.additionalValues["login.gateway.httpRoute.enabled"] = "true"
+		c.additionalValues["login.gateway.httpRoute.parentRefs[0].name"] = gatewayName
+		c.additionalValues["login.gateway.httpRoute.parentRefs[0].namespace"] = gatewayNamespace
+		c.additionalValues["login.gateway.httpRoute.parentRefs[0].sectionName"] = "web"
+	}
+}
+
+// WithExternalSecure explicitly sets whether external URLs use HTTPS.
+func WithExternalSecure(secure bool) ZitadelOption {
+	return func(c *zitadelConfig) {
+		c.externalSecure = &secure
+	}
+}
+
 // InstallZitadel installs ZITADEL via Helm with the provided options. The chart
 // is installed from the local filesystem relative to this test file location.
 // The install blocks until all resources are ready (--wait --timeout 10m).
@@ -147,13 +181,19 @@ func InstallZitadel(t *testing.T, k *k8s.KubectlOptions, opts ...ZitadelOption) 
 	chartPath := filepath.Join(repoRoot, "charts", "zitadel")
 
 	values := map[string]string{
-		"replicaCount":           "1",
-		"login.replicaCount":     "1",
-		"pdb.enabled":            "true",
-		"ingress.enabled":        "true",
-		"login.ingress.enabled":  "true",
-		"metrics.enabled":        "true",
-		"login.metrics.enabled":  "true",
+		"replicaCount":       "1",
+		"login.replicaCount": "1",
+		"pdb.enabled":        "true",
+		"metrics.enabled":    "true",
+		"login.metrics.enabled": "true",
+	}
+
+	if cfg.useGateway {
+		values["ingress.enabled"] = "false"
+		values["login.ingress.enabled"] = "false"
+	} else {
+		values["ingress.enabled"] = "true"
+		values["login.ingress.enabled"] = "true"
 	}
 
 	if cfg.externalDomain != "" {
@@ -167,6 +207,14 @@ func InstallZitadel(t *testing.T, k *k8s.KubectlOptions, opts ...ZitadelOption) 
 		values["zitadel.configmapConfig.TLS.Enabled"] = "true"
 	} else {
 		values["zitadel.configmapConfig.TLS.Enabled"] = "false"
+	}
+
+	if cfg.externalSecure != nil {
+		if *cfg.externalSecure {
+			values["zitadel.configmapConfig.ExternalSecure"] = "true"
+		} else {
+			values["zitadel.configmapConfig.ExternalSecure"] = "false"
+		}
 	}
 
 	if cfg.selfSignedCert {

--- a/test/acceptance/zitadel_test.go
+++ b/test/acceptance/zitadel_test.go
@@ -201,10 +201,10 @@ func TestInternalTLS(t *testing.T) {
 }
 
 // TestGatewayAPI validates that ZITADEL is accessible through Gateway API
-// HTTPRoute resources instead of traditional Kubernetes Ingress. This test
-// verifies that the chart's Gateway API integration works correctly with
-// Traefik as the Gateway controller, including proper appProtocol handling
-// for HTTP/2 backends (issue #580).
+// HTTPRoute and GRPCRoute resources instead of traditional Kubernetes
+// Ingress. This test verifies that the chart's Gateway API integration works
+// correctly with Traefik as the Gateway controller, including proper
+// appProtocol handling for HTTP/2 backends (issue #580).
 //
 //goland:noinspection DuplicatedCode
 func TestGatewayAPI(t *testing.T) {

--- a/test/acceptance/zitadel_test.go
+++ b/test/acceptance/zitadel_test.go
@@ -199,3 +199,36 @@ func TestInternalTLS(t *testing.T) {
 		})
 	})
 }
+
+// TestGatewayAPI validates that ZITADEL is accessible through Gateway API
+// HTTPRoute resources instead of traditional Kubernetes Ingress. This test
+// verifies that the chart's Gateway API integration works correctly with
+// Traefik as the Gateway controller, including proper appProtocol handling
+// for HTTP/2 backends (issue #580).
+//
+//goland:noinspection DuplicatedCode
+func TestGatewayAPI(t *testing.T) {
+	domain := "gateway.127.0.0.1.sslip.io"
+	apiBaseURL := BuildAPIBaseURL(domain, httpPort, false)
+	machineUsername := "zitadel-admin-sa"
+
+	testcluster.WithNamespace(t, func(ctx context.Context, k *k8s.KubectlOptions) {
+		InstallPostgres(t, k)
+		InstallZitadel(t, k,
+			WithExternalDomain(domain),
+			WithExternalPort(httpPort),
+			WithExternalSecure(false),
+			WithGateway("traefik-gateway", "kube-system"),
+			WithMachineUser("Admin", machineUsername),
+		)
+
+		t.Run("accessibility", func(t *testing.T) { CheckAccessibility(ctx, t, k, apiBaseURL) })
+		t.Run("metrics", func(t *testing.T) { CheckMetrics(ctx, t, k, false) })
+		t.Run("authenticated-api", func(t *testing.T) {
+			CheckAuthenticatedAPI(ctx, t, k, apiBaseURL, machineUsername, machineUsername+".json")
+		})
+		t.Run("uninstall", func(t *testing.T) {
+			CheckUninstall(ctx, t, k, nil)
+		})
+	})
+}

--- a/test/internal/testcluster/cluster.go
+++ b/test/internal/testcluster/cluster.go
@@ -5,7 +5,7 @@
 // discover the cluster automatically.
 //
 // Traefik is configured via a HelmChartConfig manifest to use NodePort with
-// ports 30080 (HTTP) and 30443 (HTTPS). The HTTP port redirects to HTTPS.
+// ports 30080 (HTTP) and 30443 (HTTPS).
 // The Gateway API provider is enabled and Traefik automatically creates a
 // GatewayClass and Gateway. The dynamically mapped host ports are available
 // via Cluster.HTTPSPort and Cluster.HTTPPort.

--- a/test/internal/testcluster/cluster.go
+++ b/test/internal/testcluster/cluster.go
@@ -6,7 +6,9 @@
 //
 // Traefik is configured via a HelmChartConfig manifest to use NodePort with
 // ports 30080 (HTTP) and 30443 (HTTPS). The HTTP port redirects to HTTPS.
-// The dynamically mapped host port for HTTPS is available via Cluster.HTTPSPort.
+// The Gateway API provider is enabled and Traefik automatically creates a
+// GatewayClass and Gateway. The dynamically mapped host ports are available
+// via Cluster.HTTPSPort and Cluster.HTTPPort.
 package testcluster
 
 import (
@@ -32,7 +34,11 @@ const k3sImage = "rancher/k3s:v1.34.1-k3s1"
 type Cluster struct {
 	// HTTPSPort is the dynamically mapped host port for the Traefik HTTPS
 	// NodePort (30443).
-	HTTPSPort      string
+	HTTPSPort string
+	// HTTPPort is the dynamically mapped host port for the Traefik HTTP
+	// NodePort (30080). This is also the port used by the Gateway API
+	// listener ("web" entrypoint).
+	HTTPPort  string
 	container      *k3s.K3sContainer
 	kubeconfigPath string
 }
@@ -40,8 +46,10 @@ type Cluster struct {
 // Start creates a K3s cluster with Traefik enabled, extracts its kubeconfig
 // into a temporary file, and sets the KUBECONFIG environment variable. The
 // bundled Traefik ingress controller is customized via a HelmChartConfig
-// manifest to use NodePort with dynamically mapped ports. Call Cleanup when
-// the cluster is no longer needed.
+// manifest to use NodePort with dynamically mapped ports. The Gateway API
+// provider is enabled and Traefik creates a GatewayClass ("traefik") and
+// Gateway ("traefik-gateway") automatically. Call Cleanup when the cluster
+// is no longer needed.
 func Start(ctx context.Context) (*Cluster, error) {
 	traefikPath, err := writeEmbeddedFile("traefik-config.yaml")
 	if err != nil {
@@ -88,7 +96,14 @@ func Start(ctx context.Context) (*Cluster, error) {
 		return nil, err
 	}
 
-	mapped, err := container.MappedPort(ctx, nat.Port("30443/tcp"))
+	httpsMapped, err := container.MappedPort(ctx, nat.Port("30443/tcp"))
+	if err != nil {
+		_ = os.Remove(kubeconfigFile.Name())
+		_ = container.Terminate(context.Background())
+		return nil, err
+	}
+
+	httpMapped, err := container.MappedPort(ctx, nat.Port("30080/tcp"))
 	if err != nil {
 		_ = os.Remove(kubeconfigFile.Name())
 		_ = container.Terminate(context.Background())
@@ -96,17 +111,17 @@ func Start(ctx context.Context) (*Cluster, error) {
 	}
 
 	return &Cluster{
-		HTTPSPort:      mapped.Port(),
+		HTTPSPort:      httpsMapped.Port(),
+		HTTPPort:       httpMapped.Port(),
 		container:      container,
 		kubeconfigPath: kubeconfigFile.Name(),
 	}, nil
 }
 
 // ApplyGatewayCRDs registers the Gateway API CRDs with the cluster's API
-// server using kubectl apply. This must be called after Start and only by
-// test suites that need Gateway API resources (e.g. smoke tests). The CRDs
-// are not loaded at startup to avoid interfering with Traefik's ingress
-// routing, which acceptance tests depend on.
+// server using kubectl apply. The K3s bundled traefik-crd chart already
+// installs these CRDs, so this call is idempotent. It is kept for test
+// suites (e.g. smoke tests) that call it explicitly.
 func (c *Cluster) ApplyGatewayCRDs(ctx context.Context) error {
 	path, err := writeEmbeddedFile("gateway-crds.yaml")
 	if err != nil {

--- a/test/internal/testcluster/traefik-config.yaml
+++ b/test/internal/testcluster/traefik-config.yaml
@@ -11,16 +11,18 @@ spec:
         level: DEBUG
     additionalArguments:
       - "--serverstransport.insecureskipverify=true"
+    providers:
+      kubernetesGateway:
+        enabled: true
+    gateway:
+      listeners:
+        web:
+          namespacePolicy: All
     service:
       type: NodePort
     ports:
       web:
         nodePort: 30080
-        redirections:
-          entryPoint:
-            to: websecure
-            scheme: https
-            permanent: true
       websecure:
         nodePort: 30443
     ingressClass:


### PR DESCRIPTION
The default `appProtocol` values on the Zitadel and Login services (`kubernetes.io/h2c` and `kubernetes.io/http` respectively) cause Traefik's Gateway API controller to force the wrong backend protocol on HTTPRoute traffic, resulting in HTTP 500 errors. This happens because Traefik reads `appProtocol` and overrides the protocol it would otherwise infer from the route type — HTTPRoute should use HTTP/1.1 and GRPCRoute should use h2c, but `appProtocol: kubernetes.io/h2c` forces h2c for both.

This change makes the `appProtocol` field on both Service templates conditional using `{{- with }}`, so it is omitted when set to an empty string. The default values are unchanged, so existing Ingress-based deployments are unaffected. Gateway API users can clear the field with `--set service.appProtocol=""` and `--set login.service.appProtocol=""` to let the Gateway controller infer the correct protocol from the route type.

An acceptance test (`TestGatewayAPI`) is added that deploys Zitadel with both HTTPRoute and GRPCRoute through Traefik's Gateway controller and verifies HTTP endpoints, gRPC endpoints, metrics, and authenticated API access all work correctly.

Closes #580

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes