### PR TITLE
feat: remove wait-for-postgres init container from jobs

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: v4.13.0
-version: 9.30.0
+version: 9.31.0
 kubeVersion: '>= 1.30.0-0'
 home: https://zitadel.com
 sources:

--- a/charts/zitadel/README.md
+++ b/charts/zitadel/README.md
@@ -2,7 +2,7 @@
 
 # Zitadel
 
-![Version: 9.30.0](https://img.shields.io/badge/Version-9.30.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.13.0](https://img.shields.io/badge/AppVersion-v4.13.0-informational?style=flat-square)
+![Version: 9.31.0](https://img.shields.io/badge/Version-9.31.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.13.0](https://img.shields.io/badge/AppVersion-v4.13.0-informational?style=flat-square)
 
 ## A Better Identity and Access Management Solution
 
@@ -382,9 +382,6 @@ Kubernetes: `>= 1.30.0-0`
 | startupProbe.failureThreshold | int | `30` | Number of consecutive failures before marking startup as failed and restarting the container. With periodSeconds=1 and failureThreshold=30, the container has 30 seconds to start. |
 | startupProbe.periodSeconds | int | `1` | How often (in seconds) to perform the startup check. |
 | tolerations | []Toleration | `[]` | Tolerations allow pods to be scheduled on nodes with matching taints. Taints are used to repel pods from nodes; tolerations allow exceptions. Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
-| tools.busybox.image.pullPolicy | string | `""` | Image pull policy. Defaults to the Kubernetes default for the given tag. |
-| tools.busybox.image.repository | string | `"busybox"` | The image repository for busybox. |
-| tools.busybox.image.tag | string | `"1.37"` | The busybox image tag. |
 | tools.kubectl.image.pullPolicy | string | `""` | The pull policy for the kubectl image. If left empty, Kubernetes applies its default policy depending on whether the tag is mutable or fixed. |
 | tools.kubectl.image.repository | string | `"alpine/k8s"` | The name of the image repository that contains the kubectl image. The chart automatically prepends the registry (docker.io by default) for compatibility with CRI-O v1.34+ which enforces fully qualified names. |
 | tools.kubectl.image.tag | string | `""` | The image tag to use for the kubectl image. It should be left empty to automatically default to the Kubernetes cluster version |

--- a/charts/zitadel/templates/job_init.yaml
+++ b/charts/zitadel/templates/job_init.yaml
@@ -34,23 +34,8 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       enableServiceLinks: false
       restartPolicy: Never
-      {{- if or .Values.postgresql.enabled .Values.zitadel.initContainers .Values.initJob.initContainers }}
+      {{- if or .Values.zitadel.initContainers .Values.initJob.initContainers }}
       initContainers:
-      {{- if .Values.postgresql.enabled }}
-        - name: wait-for-postgresql
-          image: {{ .Values.tools.busybox.image.repository }}:{{ .Values.tools.busybox.image.tag }}
-          command:
-            - sh
-            - -c
-            - |
-              TIMEOUT=300; elapsed=0
-              until nc -z {{ include "zitadel.postgresqlHost" . }} 5432; do
-                if [ "$elapsed" -ge "$TIMEOUT" ]; then
-                  echo "ERROR: timed out waiting for postgresql after ${TIMEOUT}s"; exit 1
-                fi
-                echo "waiting for postgresql... (${elapsed}s elapsed)"; sleep 2; elapsed=$((elapsed + 2))
-              done
-      {{- end }}
       {{- with .Values.zitadel.initContainers }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/zitadel/templates/job_init.yaml
+++ b/charts/zitadel/templates/job_init.yaml
@@ -99,6 +99,8 @@ spec:
             - name: ZITADEL_DATABASE_{{ $dbEnv }}_USER_SSL_KEY
               value: /db-ssl-user-crt/tls.key
             {{- end}}
+            - name: ZITADEL_DATABASE_{{ $dbEnv }}_AWAITINITIALCONN
+              value: "5m"
             {{- with .Values.env }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/zitadel/templates/job_setup.yaml
+++ b/charts/zitadel/templates/job_setup.yaml
@@ -122,6 +122,8 @@ spec:
             - name: ZITADEL_DATABASE_{{ $dbEnv }}_USER_SSL_KEY
               value: /db-ssl-user-crt/tls.key
             {{- end}}
+            - name: ZITADEL_DATABASE_{{ $dbEnv }}_AWAITINITIALCONN
+              value: "5m"
             {{- with .Values.env }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/zitadel/templates/job_setup.yaml
+++ b/charts/zitadel/templates/job_setup.yaml
@@ -49,23 +49,8 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       enableServiceLinks: false
       restartPolicy: Never
-      {{- if or .Values.postgresql.enabled .Values.zitadel.initContainers .Values.setupJob.initContainers }}
+      {{- if or .Values.zitadel.initContainers .Values.setupJob.initContainers }}
       initContainers:
-      {{- if .Values.postgresql.enabled }}
-        - name: wait-for-postgresql
-          image: {{ .Values.tools.busybox.image.repository }}:{{ .Values.tools.busybox.image.tag }}
-          command:
-            - sh
-            - -c
-            - |
-              TIMEOUT=300; elapsed=0
-              until nc -z {{ include "zitadel.postgresqlHost" . }} 5432; do
-                if [ "$elapsed" -ge "$TIMEOUT" ]; then
-                  echo "ERROR: timed out waiting for postgresql after ${TIMEOUT}s"; exit 1
-                fi
-                echo "waiting for postgresql... (${elapsed}s elapsed)"; sleep 2; elapsed=$((elapsed + 2))
-              done
-      {{- end }}
       {{- with .Values.zitadel.initContainers }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/zitadel/values.schema.json
+++ b/charts/zitadel/values.schema.json
@@ -1434,28 +1434,6 @@
         "tools": {
             "type": "object",
             "properties": {
-                "busybox": {
-                    "type": "object",
-                    "properties": {
-                        "image": {
-                            "type": "object",
-                            "properties": {
-                                "pullPolicy": {
-                                    "description": "Image pull policy. Defaults to the Kubernetes default for the given tag.",
-                                    "type": "string"
-                                },
-                                "repository": {
-                                    "description": "The image repository for busybox.",
-                                    "type": "string"
-                                },
-                                "tag": {
-                                    "description": "The busybox image tag.",
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
                 "kubectl": {
                     "type": "object",
                     "properties": {

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -1395,17 +1395,6 @@ tools:
       #   cpu: 50m
       #   memory: 32Mi
 
-  # Configuration for the busybox image used by the wait-for-postgresql initContainer.
-  # Override when running in air-gapped or restricted-registry environments.
-  busybox:
-    image:
-      # -- The image repository for busybox.
-      repository: "busybox"
-      # -- The busybox image tag.
-      tag: "1.37"
-      # -- Image pull policy. Defaults to the Kubernetes default for the given tag.
-      pullPolicy: ""
-
   # Configuration for the kubectl helper image used by init containers and jobs
   # for lightweight Kubernetes API operations. This image is used by the setup
   # job's machinekey containers and the cleanup job.


### PR DESCRIPTION
Removes the busybox-based `wait-for-postgresql` init containers from the init and setup jobs. ZITADEL handles database connection retries natively via `awaitInitialConn`, making these redundant. This eliminates the `busybox` image dependency from the job pods. The `wait-for-zitadel` init container in the Login deployment is unchanged.

Follows the same approach as #583 which removed it from the deployment.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes