### PR TITLE
feat: GRPCRoute explicit content-type: application/grpc.* header match.

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: v4.13.0
-version: 9.33.0
+version: 9.33.1
 kubeVersion: '>= 1.30.0-0'
 home: https://zitadel.com
 sources:

--- a/charts/zitadel/README.md
+++ b/charts/zitadel/README.md
@@ -2,7 +2,7 @@
 
 # Zitadel
 
-![Version: 9.33.0](https://img.shields.io/badge/Version-9.33.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.13.0](https://img.shields.io/badge/AppVersion-v4.13.0-informational?style=flat-square)
+![Version: 9.33.1](https://img.shields.io/badge/Version-9.33.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.13.0](https://img.shields.io/badge/AppVersion-v4.13.0-informational?style=flat-square)
 
 ## A Better Identity and Access Management Solution
 

--- a/charts/zitadel/templates/grpcroute_zitadel.yaml
+++ b/charts/zitadel/templates/grpcroute_zitadel.yaml
@@ -40,4 +40,9 @@ spec:
       filters:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      matches:
+        - headers:
+            - name: "content-type"
+              type: "RegularExpression"
+              value: "application/grpc.*"
 {{- end }}


### PR DESCRIPTION
The upstream Zitadel GRPCRoute had no rules[].matches. In Cilium's Envoy implementation, a GRPCRoute without explicit matches can lose routing priority against an HTTPRoute with path / when both share the same hostname. gRPC requests were falling through to the HTTPRoute → routed as HTTP/1.1 → Zitadel returns EOF.

This makes the route explicitly gRPC-only, giving Cilium/Envoy a clear signal to prefer this route over the HTTPRoute for gRPC traffic.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
