### PR TITLE
fix: ensure nameOverride works for container names

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: v4.13.0
-version: 9.33.0
+version: 9.33.2
 kubeVersion: '>= 1.30.0-0'
 home: https://zitadel.com
 sources:

--- a/charts/zitadel/README.md
+++ b/charts/zitadel/README.md
@@ -2,7 +2,7 @@
 
 # Zitadel
 
-![Version: 9.33.0](https://img.shields.io/badge/Version-9.33.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.13.0](https://img.shields.io/badge/AppVersion-v4.13.0-informational?style=flat-square)
+![Version: 9.33.2](https://img.shields.io/badge/Version-9.33.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.13.0](https://img.shields.io/badge/AppVersion-v4.13.0-informational?style=flat-square)
 
 ## A Better Identity and Access Management Solution
 

--- a/charts/zitadel/templates/deployment_login.yaml
+++ b/charts/zitadel/templates/deployment_login.yaml
@@ -50,7 +50,7 @@ spec:
       {{- if .Values.login.extraContainers }}
         {{- toYaml .Values.login.extraContainers | nindent 8 }}
       {{- end }}
-        - name: {{ .Chart.Name }}-login
+        - name: {{ include "zitadel.login.name" . }}
           securityContext:
             {{- include "login.securityContext" . | nindent 14 }}
           image: "{{ .Values.login.image.repository }}:{{ .Values.login.image.tag | default .Chart.AppVersion }}"

--- a/charts/zitadel/templates/deployment_zitadel.yaml
+++ b/charts/zitadel/templates/deployment_zitadel.yaml
@@ -54,7 +54,7 @@ spec:
       {{- if .Values.extraContainers }}
         {{- toYaml .Values.extraContainers | nindent 8 }}
       {{- end }}
-        - name: {{ .Chart.Name }}
+        - name: {{ include "zitadel.name" . | quote }}
           securityContext:
             {{- include "zitadel.securityContext" . | nindent 14 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/zitadel/templates/job_cleanup.yaml
+++ b/charts/zitadel/templates/job_cleanup.yaml
@@ -35,7 +35,7 @@ spec:
       enableServiceLinks: false
       restartPolicy: Never
       containers:
-        - name: "{{ .Chart.Name }}-cleanup"
+        - name: {{ printf "%s-cleanup" ((include "zitadel.name" .) | trunc 55 | trimSuffix "-") }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 14 }}
           image: {{ include "kubectl.image" . }}

--- a/charts/zitadel/templates/job_init.yaml
+++ b/charts/zitadel/templates/job_init.yaml
@@ -50,7 +50,7 @@ spec:
       {{- if .Values.initJob.extraContainers }}
         {{- toYaml .Values.initJob.extraContainers | nindent 8 }}
       {{- end }}
-        - name: "{{ .Chart.Name }}-init"
+        - name: {{ printf "%s-init" (include "zitadel.name" . | trunc 58 | trimSuffix "-") }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 14 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/zitadel/templates/job_setup.yaml
+++ b/charts/zitadel/templates/job_setup.yaml
@@ -65,7 +65,7 @@ spec:
       {{- if .Values.setupJob.extraContainers }}
         {{- toYaml .Values.setupJob.extraContainers | nindent 8 }}
       {{- end }}
-        - name: "{{ .Chart.Name }}-setup"
+        - name: {{ printf "%s-setup" ((include "zitadel.name" .) | trunc 57 | trimSuffix "-") }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 14 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -167,7 +167,7 @@ spec:
           resources:
             {{- toYaml .Values.setupJob.resources | nindent 12 }}
         {{- if and (not $skipFirstInstance) $hasMachine }}
-        - name: "{{ .Chart.Name}}-machinekey"
+        - name: {{ printf "%s-machinekey" ((include "zitadel.name" .) | trunc 52 | trimSuffix "-") }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 14 }}
           image: {{ include "kubectl.image" . }}
@@ -176,11 +176,11 @@ spec:
             - sh
             - -c
             - |
-              until [ ! -z $(kubectl --namespace={{ .Release.Namespace }} get pod ${POD_NAME} --output=jsonpath="{.status.containerStatuses[?(@.name=='{{ .Chart.Name }}-setup')].state.terminated}") ]; do
-                echo 'waiting for {{ .Chart.Name }}-setup container to terminate';
+              until [ -n "$(kubectl --namespace={{ .Release.Namespace }} get pod ${POD_NAME} --output=jsonpath="{.status.containerStatuses[?(@.name=='{{ include "zitadel.name" . }}-setup')].state.terminated}")" ]; do
+                echo 'waiting for {{ include "zitadel.name" . }}-setup container to terminate';
                 sleep 5;
               done &&
-              echo '{{ .Chart.Name }}-setup container terminated' &&
+              echo '{{ include "zitadel.name" . }}-setup container terminated' &&
               if [ -f /machinekey/sa.json ]; then
                 kubectl --namespace={{ .Release.Namespace }} create secret generic {{ .Values.zitadel.configmapConfig.FirstInstance.Org.Machine.Machine.Username }} \
                   --from-file={{ .Values.zitadel.configmapConfig.FirstInstance.Org.Machine.Machine.Username }}.json=/machinekey/sa.json \
@@ -212,7 +212,7 @@ spec:
           {{- end }}
       {{- end }}
       {{- if and (not $skipFirstInstance) $hasMachinePat }}
-        - name: "{{ .Chart.Name }}-machine-pat"
+        - name: {{ printf "%s-machine-pat" ((include "zitadel.name" .) | trunc 51 | trimSuffix "-") }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 14 }}
           image: {{ include "kubectl.image" . }}
@@ -221,11 +221,11 @@ spec:
             - sh
             - -c
             - |
-              until [ ! -z $(kubectl --namespace={{ .Release.Namespace }} get pod ${POD_NAME} --output=jsonpath="{.status.containerStatuses[?(@.name=='{{ .Chart.Name }}-setup')].state.terminated}") ]; do
-                echo 'waiting for {{ .Chart.Name }}-setup container to terminate';
+              until [ -n "$(kubectl --namespace={{ .Release.Namespace }} get pod "${POD_NAME}" --output=jsonpath="{.status.containerStatuses[?(@.name=='{{ include "zitadel.name" . }}-setup')].state.terminated}")" ]; do
+                echo 'waiting for {{ include "zitadel.name" . }}-setup container to terminate';
                 sleep 5;
               done &&
-              echo '{{ .Chart.Name }}-setup container terminated' &&
+              echo '{{ include "zitadel.name" . }}-setup container terminated' &&
               if [ -f /machinekey/pat ]; then
                 kubectl --namespace={{ .Release.Namespace }} create secret generic {{ .Values.zitadel.configmapConfig.FirstInstance.Org.Machine.Machine.Username }}-pat \
                   --from-file=pat=/machinekey/pat \
@@ -257,7 +257,7 @@ spec:
           {{- end }}
       {{- end }}
       {{- if and (not $skipFirstInstance) $hasLoginClient }}
-        - name: "{{ .Chart.Name}}-login-client-pat"
+        - name: {{ printf "%s-login-client-pat" ((include "zitadel.name" .) | trunc 46 | trimSuffix "-") }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 14 }}
           image: {{ include "kubectl.image" . }}
@@ -266,11 +266,11 @@ spec:
             - sh
             - -c
             - |
-              until [ ! -z $(kubectl --namespace={{ .Release.Namespace }} get pod ${POD_NAME} --output=jsonpath="{.status.containerStatuses[?(@.name=='{{ .Chart.Name }}-setup')].state.terminated}") ]; do
-                echo 'waiting for {{ .Chart.Name }}-setup container to terminate';
+              until [ -n "$(kubectl --namespace={{ .Release.Namespace }} get pod ${POD_NAME} --output=jsonpath="{.status.containerStatuses[?(@.name=='{{ include "zitadel.name" . }}-setup')].state.terminated}")" ]; do
+                echo 'waiting for {{ include "zitadel.name" . }}-setup container to terminate';
                 sleep 5;
               done &&
-              echo '{{ .Chart.Name }}-setup container terminated' &&
+              echo '{{ include "zitadel.name" . }}-setup container terminated' &&
               if [ -f /login-client/pat ]; then
                 kubectl --namespace={{ .Release.Namespace }} create secret generic {{ .Values.login.loginClientSecretPrefix }}login-client \
                   --from-file=pat=/login-client/pat \


### PR DESCRIPTION
> [!Note]
> I increased the Chart version to 9.33.2 so it can be merged after #588 which bumps to 9.33.1

When creating a chart like this:

```yaml
apiVersion: v2
name: zitadel
# renovate: datasource=github-releases depName=zitadel/zitadel-charts
version: 9.33.2
# renovate: datasource=github-releases depName=zitadel/zitadel
appVersion: v4.13.1
dependencies:
  - name: zitadel
    alias: upstream
    # renovate: datasource=github-releases depName=zitadel/zitadel-charts
    version: 9.33.2
    repository: "oci://ghcr.io/zitadel/zitadel-charts"
```

With following values:

```yaml
upstream:
  nameOverride: zitadel

  zitadel:
    ...
    ...
```

Without this fix it would use the name upstream for image and some of the setupjob logs.

With this PR that is fixed to consistently render `zitadel` like if someone would not be wrapping the chart.

The reason we wrap the chart like this is so we can predefine values for our ArgoCD app.

### Test

I tested it locally as following: _(excluding `# Source: zitadel/charts/upstream` lines)_

```shell
$ helm template \
    --namespace=zitadel
    zitadel charts/zitadel | rg -A1 -B1 upstream | rg -V Source
ripgrep 15.1.0
```

Without this PR a all images would be named `upstream`.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
