### PR TITLE
feat: add configurable matches to GRPCRoute

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: v4.13.0
-version: 9.33.2
+version: 9.34.0
 kubeVersion: '>= 1.30.0-0'
 home: https://zitadel.com
 sources:

--- a/charts/zitadel/README.md
+++ b/charts/zitadel/README.md
@@ -2,7 +2,7 @@
 
 # Zitadel
 
-![Version: 9.33.2](https://img.shields.io/badge/Version-9.33.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.13.0](https://img.shields.io/badge/AppVersion-v4.13.0-informational?style=flat-square)
+![Version: 9.34.0](https://img.shields.io/badge/Version-9.34.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.13.0](https://img.shields.io/badge/AppVersion-v4.13.0-informational?style=flat-square)
 
 ## A Better Identity and Access Management Solution
 
@@ -191,6 +191,7 @@ Kubernetes: `>= 1.30.0-0`
 | gateway.grpcRoute.filters | []GRPCRouteFilter | `[]` | Filters to apply to all rules. These define processing steps for gRPC requests, such as header modification or mirroring. Ref: https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GRPCRouteFilter |
 | gateway.grpcRoute.hostnames | list | `[]` | Hostnames for the GRPCRoute. If empty, defaults to ExternalDomain. |
 | gateway.grpcRoute.labels | map[string]string | `{}` | Additional labels to apply to the GRPCRoute resource. |
+| gateway.grpcRoute.matches | []GRPCRouteMatch | `[]` | Matches to apply to the GRPCRoute rule. If empty, the route matches all gRPC requests per the Gateway API spec. Some implementations (e.g. Cilium) may require explicit matches to correctly prioritize GRPCRoute over HTTPRoute when both share the same hostname. Ref: https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GRPCRouteMatch |
 | gateway.grpcRoute.parentRefs | list | `[]` | References to Gateway resources that this route should be attached to. Example:   parentRefs:     - name: my-gateway |
 | gateway.httpRoute.annotations | map[string]string | `{}` | Annotations to apply to the HTTPRoute resource. |
 | gateway.httpRoute.enabled | bool | `false` | If true, creates an HTTPRoute resource for the ZITADEL service. |

--- a/charts/zitadel/templates/grpcroute_zitadel.yaml
+++ b/charts/zitadel/templates/grpcroute_zitadel.yaml
@@ -3,6 +3,7 @@
 {{- $svcPort := .Values.service.port -}}
 {{- $externalDomain := .Values.zitadel.configmapConfig.ExternalDomain -}}
 {{- $filters := .Values.gateway.grpcRoute.filters -}}
+{{- $matches := .Values.gateway.grpcRoute.matches -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: GRPCRoute
 metadata:
@@ -38,6 +39,10 @@ spec:
           port: {{ $svcPort }}
       {{- with $filters }}
       filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $matches }}
+      matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/zitadel/values.schema.json
+++ b/charts/zitadel/values.schema.json
@@ -153,6 +153,13 @@
                             "description": "(map[string]string) Additional labels to apply to the GRPCRoute resource.",
                             "type": "object"
                         },
+                        "matches": {
+                            "description": "([]GRPCRouteMatch) Matches to apply to the GRPCRoute rule. If empty, the route matches all gRPC requests per the Gateway API spec. Some implementations (e.g. Cilium) may require explicit matches to correctly prioritize GRPCRoute over HTTPRoute when both share the same hostname. Ref: https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GRPCRouteMatch",
+                            "type": "array",
+                            "items": {
+                                "type": "object"
+                            }
+                        },
                         "parentRefs": {
                             "description": "References to Gateway resources that this route should be attached to. Example: parentRefs: - name: my-gateway",
                             "type": "array",

--- a/charts/zitadel/values.schema.json
+++ b/charts/zitadel/values.schema.json
@@ -157,7 +157,40 @@
                             "description": "([]GRPCRouteMatch) Matches to apply to the GRPCRoute rule. If empty, the route matches all gRPC requests per the Gateway API spec. Some implementations (e.g. Cilium) may require explicit matches to correctly prioritize GRPCRoute over HTTPRoute when both share the same hostname. Ref: https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GRPCRouteMatch",
                             "type": "array",
                             "items": {
-                                "type": "object"
+                                "type": "object",
+                                "properties": {
+                                    "headers": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                },
+                                                "value": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "method": {
+                                        "type": "object",
+                                        "properties": {
+                                            "method": {
+                                                "type": "string"
+                                            },
+                                            "service": {
+                                                "type": "string"
+                                            },
+                                            "type": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         },
                         "parentRefs": {

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -977,6 +977,12 @@ gateway:
     # steps for gRPC requests, such as header modification or mirroring.
     # Ref: https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GRPCRouteFilter
     filters: []  # @schema item: object; itemProperties: {"type": {"type": "string"}}
+    # -- ([]GRPCRouteMatch) Matches to apply to the GRPCRoute rule. If empty, the
+    # route matches all gRPC requests per the Gateway API spec. Some implementations
+    # (e.g. Cilium) may require explicit matches to correctly prioritize GRPCRoute
+    # over HTTPRoute when both share the same hostname.
+    # Ref: https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GRPCRouteMatch
+    matches: []  # @schema item: object
 
 # @schema $ref: $k8s/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements
 # -- (ResourceRequirements) CPU and memory resource requests and limits for the ZITADEL container.

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -982,7 +982,7 @@ gateway:
     # (e.g. Cilium) may require explicit matches to correctly prioritize GRPCRoute
     # over HTTPRoute when both share the same hostname.
     # Ref: https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GRPCRouteMatch
-    matches: []  # @schema item: object
+    matches: []  # @schema item: object; itemProperties: {"headers": {"type": "array", "items": {"type": "object", "properties": {"name": {"type": "string"}, "type": {"type": "string"}, "value": {"type": "string"}}}}, "method": {"type": "object", "properties": {"type": {"type": "string"}, "service": {"type": "string"}, "method": {"type": "string"}}}}
 
 # @schema $ref: $k8s/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements
 # -- (ResourceRequirements) CPU and memory resource requests and limits for the ZITADEL container.

--- a/test/smoke/gateway_test.go
+++ b/test/smoke/gateway_test.go
@@ -284,6 +284,34 @@ func TestGatewayGRPCRouteMatrix(t *testing.T) {
 			},
 		},
 		{
+			name: "matches",
+			setValues: map[string]string{
+				"gateway.grpcRoute.enabled":                   "true",
+				"gateway.grpcRoute.parentRefs[0].name":        "my-gw",
+				"gateway.grpcRoute.matches[0].headers[0].name":  "content-type",
+				"gateway.grpcRoute.matches[0].headers[0].type":  "RegularExpression",
+				"gateway.grpcRoute.matches[0].headers[0].value": "application/grpc.*",
+			},
+			zitadel: &assert.GRPCRouteAssertion{
+				Spec: assert.GRPCRouteSpecAssertion{
+					Rules: assert.Some([]assert.GRPCRouteRuleAssertion{
+						{
+							Matches: assert.Some([]assert.GRPCRouteMatchAssertion{
+								{
+									Headers: assert.Some([]assert.GRPCHeaderMatchAssertion{
+										{
+											Name:  assert.Some(gatewayv1.GRPCHeaderName("content-type")),
+											Value: assert.Some("application/grpc.*"),
+										},
+									}),
+								},
+							}),
+						},
+					}),
+				},
+			},
+		},
+		{
 			name: "filters",
 			setValues: map[string]string{
 				"gateway.grpcRoute.enabled":                                       "true",


### PR DESCRIPTION
Adds an optional `matches` field to `gateway.grpcRoute` so users can explicitly match gRPC traffic by headers. Some Gateway implementations (e.g. Cilium) do not correctly prioritize GRPCRoute over HTTPRoute when both share the same hostname, causing gRPC requests to fall through to the HTTPRoute and fail with EOF. This lets affected users set an explicit `content-type: application/grpc.*` header match to work around the issue without hardcoding a Cilium-specific workaround into the chart for all implementations. The field defaults to an empty list, preserving existing behavior.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes