### PR TITLE
fix: ArgoCD sync has grpc route diff

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: v4.13.0
-version: 9.34.0
+version: 9.34.1
 kubeVersion: '>= 1.30.0-0'
 home: https://zitadel.com
 sources:

--- a/charts/zitadel/README.md
+++ b/charts/zitadel/README.md
@@ -2,7 +2,7 @@
 
 # Zitadel
 
-![Version: 9.34.0](https://img.shields.io/badge/Version-9.34.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.13.0](https://img.shields.io/badge/AppVersion-v4.13.0-informational?style=flat-square)
+![Version: 9.34.1](https://img.shields.io/badge/Version-9.34.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.13.0](https://img.shields.io/badge/AppVersion-v4.13.0-informational?style=flat-square)
 
 ## A Better Identity and Access Management Solution
 

--- a/charts/zitadel/templates/grpcroute_zitadel.yaml
+++ b/charts/zitadel/templates/grpcroute_zitadel.yaml
@@ -35,8 +35,11 @@ spec:
   {{- end }}
   rules:
     - backendRefs:
-        - name: {{ $fullName }}
+        - group: ''
+          kind: Service
+          name: {{ $fullName }}
           port: {{ $svcPort }}
+          weight: 1
       {{- with $filters }}
       filters:
         {{- toYaml . | nindent 8 }}

--- a/test/smoke/gateway_test.go
+++ b/test/smoke/gateway_test.go
@@ -312,6 +312,32 @@ func TestGatewayGRPCRouteMatrix(t *testing.T) {
 			},
 		},
 		{
+			name: "backend-refs",
+			setValues: map[string]string{
+				"gateway.grpcRoute.enabled":            "true",
+				"gateway.grpcRoute.parentRefs[0].name": "my-gw",
+			},
+			zitadel: &assert.GRPCRouteAssertion{
+				Spec: assert.GRPCRouteSpecAssertion{
+					Rules: assert.Some([]assert.GRPCRouteRuleAssertion{
+						{
+							BackendRefs: assert.Some([]assert.GRPCBackendRefAssertion{
+								{
+									BackendRef: assert.BackendRefAssertion{
+										BackendObjectReference: assert.BackendObjectReferenceAssertion{
+											Group: assert.SomePtr(gatewayv1.Group("")),
+											Kind:  assert.SomePtr(gatewayv1.Kind("Service")),
+										},
+										Weight: assert.SomePtr(int32(1)),
+									},
+								},
+							}),
+						},
+					}),
+				},
+			},
+		},
+		{
 			name: "filters",
 			setValues: map[string]string{
 				"gateway.grpcRoute.enabled":                                       "true",


### PR DESCRIPTION
This resolves following diff in ArgoCD as those fields would be automatically set if not defined. Due to that it causes a continuous diff when deploying via ArgoCD.
With this PR that diff is resolved. See following screenshot for the problem.

<img width="593" height="322" alt="image" src="https://github.com/user-attachments/assets/c71ffe0e-f866-4735-b3e6-e66ba80463c9" />

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
