### PR TITLE
fix: use /ready endpoint for login readiness and startup probes

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: zitadel
 description: A Helm chart for ZITADEL
 type: application
-appVersion: v4.13.0
-version: 9.34.0
+appVersion: v4.13.1
+version: 9.34.1
 kubeVersion: '>= 1.30.0-0'
 home: https://zitadel.com
 sources:

--- a/charts/zitadel/README.md
+++ b/charts/zitadel/README.md
@@ -2,7 +2,7 @@
 
 # Zitadel
 
-![Version: 9.34.0](https://img.shields.io/badge/Version-9.34.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.13.0](https://img.shields.io/badge/AppVersion-v4.13.0-informational?style=flat-square)
+![Version: 9.34.1](https://img.shields.io/badge/Version-9.34.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.13.1](https://img.shields.io/badge/AppVersion-v4.13.1-informational?style=flat-square)
 
 ## A Better Identity and Access Management Solution
 

--- a/charts/zitadel/templates/_helpers.tpl
+++ b/charts/zitadel/templates/_helpers.tpl
@@ -359,7 +359,7 @@ performs a more thorough check to verify that the service is fully ready to
 accept user traffic and can connect to its required backend dependencies.
 */}}
 {{- define "login.readinessProbePath" -}}
-/ui/v2/login/security
+/ui/v2/login/ready
 {{- end -}}
 
 {{/*
@@ -368,7 +368,7 @@ thorough check as the readiness probe to ensure the application is fully
 initialized before its other probes (liveness, readiness) take over.
 */}}
 {{- define "login.startupProbePath" -}}
-/ui/v2/login/security
+/ui/v2/login/ready
 {{- end -}}
 
 {{/*

--- a/charts/zitadel/templates/configmap_login.yaml
+++ b/charts/zitadel/templates/configmap_login.yaml
@@ -17,7 +17,7 @@ data:
     {{- else }}
       ZITADEL_SERVICE_USER_TOKEN_FILE="/login-client/pat"
       ZITADEL_API_URL="http{{ if and .Values.zitadel.configmapConfig.TLS .Values.zitadel.configmapConfig.TLS.Enabled }}s{{ end }}://{{ include "zitadel.fullname" . }}:{{ .Values.service.port }}"
-      CUSTOM_REQUEST_HEADERS="Host:{{ .Values.zitadel.configmapConfig.ExternalDomain }},X-Zitadel-Public-Host:{{ .Values.zitadel.configmapConfig.ExternalDomain }}"
+      CUSTOM_REQUEST_HEADERS="Host:{{ .Values.zitadel.configmapConfig.ExternalDomain }},X-Zitadel-Instance-Host:{{ .Values.zitadel.configmapConfig.ExternalDomain }},X-Zitadel-Public-Host:{{ .Values.zitadel.configmapConfig.ExternalDomain }}"
       {{- if .Values.zitadel.selfSignedCert.enabled }}
       NODE_TLS_REJECT_UNAUTHORIZED=0
       {{- end }}

--- a/charts/zitadel/templates/configmap_login.yaml
+++ b/charts/zitadel/templates/configmap_login.yaml
@@ -17,7 +17,7 @@ data:
     {{- else }}
       ZITADEL_SERVICE_USER_TOKEN_FILE="/login-client/pat"
       ZITADEL_API_URL="http{{ if and .Values.zitadel.configmapConfig.TLS .Values.zitadel.configmapConfig.TLS.Enabled }}s{{ end }}://{{ include "zitadel.fullname" . }}:{{ .Values.service.port }}"
-      CUSTOM_REQUEST_HEADERS="Host:{{ .Values.zitadel.configmapConfig.ExternalDomain }},X-Zitadel-Instance-Host:{{ .Values.zitadel.configmapConfig.ExternalDomain }},X-Zitadel-Public-Host:{{ .Values.zitadel.configmapConfig.ExternalDomain }}"
+      CUSTOM_REQUEST_HEADERS="Host:{{ .Values.zitadel.configmapConfig.ExternalDomain }},X-Zitadel-Public-Host:{{ .Values.zitadel.configmapConfig.ExternalDomain }}"
       {{- if .Values.zitadel.selfSignedCert.enabled }}
       NODE_TLS_REJECT_UNAUTHORIZED=0
       {{- end }}


### PR DESCRIPTION
The login readiness and startup probes pointed at `/ui/v2/login/security`, a user-facing endpoint that was never designed as a health check. It depends on incoming request headers for instance resolution, which breaks under certain configurations and newer Zitadel versions where `InstanceHostHeaders` resolution is stricter.

The `/ui/v2/login/ready` endpoint was purpose-built as a readiness probe in zitadel/zitadel#11828. It uses `ZITADEL_API_URL` directly (no header dependency), calls `getGeneralSettings()`, and returns 503 on failure. This makes it reliable regardless of how instance host headers are configured.

Also bumps appVersion to v4.13.1.

Closes #592

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes