### PR TITLE
fix: merge user-supplied SystemAPIUsers list with login-client

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: v4.14.0
-version: 10.0.2
+version: 10.0.3
 kubeVersion: '>= 1.30.0-0'
 home: https://zitadel.com
 sources:

--- a/charts/zitadel/README.md
+++ b/charts/zitadel/README.md
@@ -2,7 +2,7 @@
 
 # Zitadel
 
-![Version: 10.0.2](https://img.shields.io/badge/Version-10.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.14.0](https://img.shields.io/badge/AppVersion-v4.14.0-informational?style=flat-square)
+![Version: 10.0.3](https://img.shields.io/badge/Version-10.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.14.0](https://img.shields.io/badge/AppVersion-v4.14.0-informational?style=flat-square)
 
 ## A Better Identity and Access Management Solution
 

--- a/charts/zitadel/templates/_helpers.tpl
+++ b/charts/zitadel/templates/_helpers.tpl
@@ -485,6 +485,23 @@ values always win.
 {{- define "zitadel.mergedConfigmapConfig" -}}
 {{- $config := deepCopy .Values.zitadel.configmapConfig -}}
 {{- if .Values.login.enabled -}}
+{{/*
+Normalize a user-supplied SystemAPIUsers list into a map before merging.
+ZITADEL accepts SystemAPIUsers either as a map (keyed by username) or as a
+list of single-key maps, but Helm's mergeOverwrite only deep-merges maps. A
+list value would overwrite the chart's login-client entry wholesale, leaving
+the login pod without credentials and never becoming ready. Folding the list
+into a map lets the entries merge instead of clobbering each other.
+See https://github.com/zitadel/zitadel-charts/issues/602.
+*/}}
+{{- $existing := $config.SystemAPIUsers | default dict -}}
+{{- if kindIs "slice" $existing -}}
+{{- $asMap := dict -}}
+{{- range $entry := $existing -}}
+{{- $asMap = mergeOverwrite $asMap $entry -}}
+{{- end -}}
+{{- $_ := set $config "SystemAPIUsers" $asMap -}}
+{{- end -}}
 {{- $loginUser := dict "SystemAPIUsers" (dict "login-client" (dict "Path" "/secrets/login-client/tls.crt" "Memberships" (list (dict "MemberType" "System" "Roles" (list "IAM_LOGIN_CLIENT"))))) -}}
 {{- $config = mergeOverwrite $loginUser $config -}}
 {{- end -}}

--- a/charts/zitadel/templates/_helpers.tpl
+++ b/charts/zitadel/templates/_helpers.tpl
@@ -494,7 +494,7 @@ the login pod without credentials and never becoming ready. Folding the list
 into a map lets the entries merge instead of clobbering each other.
 See https://github.com/zitadel/zitadel-charts/issues/602.
 */}}
-{{- $existing := $config.SystemAPIUsers | default dict -}}
+{{- $existing := $config.SystemAPIUsers -}}
 {{- if kindIs "slice" $existing -}}
 {{- $asMap := dict -}}
 {{- range $entry := $existing -}}

--- a/test/smoke/configmap_test.go
+++ b/test/smoke/configmap_test.go
@@ -10,6 +10,12 @@ import (
 	"github.com/zitadel/zitadel-charts/test/support"
 )
 
+// validSystemUserKeyData is a base64-encoded RSA public key (PEM). ZITADEL's
+// config loader base64-decodes SystemAPIUsers KeyData, so the value must be
+// valid base64 for the setup job to start. The key itself is only parsed when
+// that system user authenticates, which this render-focused test never does.
+const validSystemUserKeyData = "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUFzRjdQWlhZUzV6TWFESHlVK1I3ZQovQlIyRUkzTkZNSWlLSWJrNFk2WXZQNHV1S3huTHlLMy9pM0t0ZUEzOE5Bb21rZTdnNXNkM1VJSDIrdGllTmVtCmlyQUlvUWwwZDZOMTUrYU5VTG9haFpFTjdnVVBjQWJXeW1OeUtYZ1BLMkVYc2lhbzFBcVFVQVdnb2UxYjZ2a08KdVdHSklIRVlhYUlmQjdoVlNQTjh5UTJha2xkYTdIU3kzK2ZpVHVBT3dxRlJqSW51OEROL1hHcC9YYTNIK2kySApCWVUvZ2syT3UvMHFxbDRXY0ZxbVJVQjdKRzZFZEZNSStzUG5iOEkzWTFSazV0Q1Y3TDk0bjhJdVg3MW5EUXdzCjJ6THlpRGFjQkxsWGdyZmx1ZFB1akNMelVtTDIxMlVIeDBtT0UvSm5JdTBzaU54ejEzRXhOcFljc3lkcE1mMFMKWlFJREFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg=="
+
 func TestConfigMapMatrix(t *testing.T) {
 	t.Parallel()
 
@@ -59,7 +65,7 @@ func TestConfigMapMatrix(t *testing.T) {
 			name: "user-systemapiusers-list-merges-login-client",
 			setValues: map[string]string{
 				"login.enabled": "true",
-				"zitadel.configmapConfig.SystemAPIUsers[0].superuser.KeyData": "BASE64DATA",
+				"zitadel.configmapConfig.SystemAPIUsers[0].superuser.KeyData": validSystemUserKeyData,
 			},
 			zitadel: &assert.ConfigMapAssertion{
 				Data: assert.Matching[map[string]string](gomega.And(

--- a/test/smoke/configmap_test.go
+++ b/test/smoke/configmap_test.go
@@ -52,6 +52,27 @@ func TestConfigMapMatrix(t *testing.T) {
 			},
 		},
 		{
+			// Regression for https://github.com/zitadel/zitadel-charts/issues/602:
+			// a user-supplied SystemAPIUsers list (dash form) must merge with the
+			// chart's login-client entry rather than overwriting it. Both the
+			// operator's "superuser" and the generated "login-client" must appear.
+			name: "user-systemapiusers-list-merges-login-client",
+			setValues: map[string]string{
+				"login.enabled": "true",
+				"zitadel.configmapConfig.SystemAPIUsers[0].superuser.KeyData": "BASE64DATA",
+			},
+			zitadel: &assert.ConfigMapAssertion{
+				Data: assert.Matching[map[string]string](gomega.And(
+					gomega.HaveKeyWithValue("zitadel-config-yaml",
+						gomega.ContainSubstring("login-client")),
+					gomega.HaveKeyWithValue("zitadel-config-yaml",
+						gomega.ContainSubstring("IAM_LOGIN_CLIENT")),
+					gomega.HaveKeyWithValue("zitadel-config-yaml",
+						gomega.ContainSubstring("superuser")),
+				)),
+			},
+		},
+		{
 			name: "both-enabled-with-annotations",
 			setValues: map[string]string{
 				"configMap.annotations.owner":      "platform-team",


### PR DESCRIPTION
### Description

Fixes #602.

When a user supplies their own `SystemAPIUsers` in `zitadel.configmapConfig` as a YAML **list** (the form ZITADEL's own configuration docs use), the `zitadel.mergedConfigmapConfig` helper overwrote the chart's generated `login-client` entry instead of merging with it. The login pod then never received its credentials, never became ready, and the `helm upgrade` hung. Supplying `SystemAPIUsers` as a map already merged correctly; only the list form was affected.

The helper now normalizes a list-form `SystemAPIUsers` into a map before merging, so the operator's own entries and the chart's `login-client` coexist. Output for the map form and for the default case (no custom `SystemAPIUsers`) is unchanged, so this is not a breaking change.

Verified on a local k3d cluster:
- **Default** (no custom `SystemAPIUsers`): installs cleanly, login pod Ready — no behavioural change.
- **List-form custom `SystemAPIUsers`**: setup job succeeds, zitadel and login pods Ready, and the rendered config contains both `login-client` and the user's own entry.

A render assertion covering the list-form merge was added to `test/smoke/configmap_test.go`, and the chart version was bumped to 10.0.4 — the next free patch after merging `main` (the previous patch was already taken by #605).

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes


