### PR TITLE
feat: update appVersion to v4.15.3

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zitadel
 description: A Helm chart for ZITADEL
 type: application
-appVersion: v4.15.0
+appVersion: v4.15.2
 version: 10.0.3
 kubeVersion: '>= 1.30.0-0'
 home: https://zitadel.com

--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zitadel
 description: A Helm chart for ZITADEL
 type: application
-appVersion: v4.15.2
+appVersion: v4.15.3
 version: 10.0.3
 kubeVersion: '>= 1.30.0-0'
 home: https://zitadel.com

--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: zitadel
 description: A Helm chart for ZITADEL
 type: application
-appVersion: v4.14.0
-version: 10.0.2
+appVersion: v4.15.0
+version: 10.0.3
 kubeVersion: '>= 1.30.0-0'
 home: https://zitadel.com
 sources:

--- a/charts/zitadel/README.md
+++ b/charts/zitadel/README.md
@@ -2,7 +2,7 @@
 
 # Zitadel
 
-![Version: 10.0.2](https://img.shields.io/badge/Version-10.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.14.0](https://img.shields.io/badge/AppVersion-v4.14.0-informational?style=flat-square)
+![Version: 10.0.3](https://img.shields.io/badge/Version-10.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.15.3](https://img.shields.io/badge/AppVersion-v4.15.3-informational?style=flat-square)
 
 ## A Better Identity and Access Management Solution
 


### PR DESCRIPTION
### Description

Bumps the chart's `appVersion` to the latest ZITADEL release, `v4.15.3` (released 2026-06-22), and regenerates the chart `README.md` badges via `helm-docs` so the documented `Version`/`AppVersion` match `Chart.yaml`. The chart `version` is `10.0.3`.

This supersedes #598, which set `appVersion: v4.15.2` and left the README badges stale at `10.0.2` / `v4.14.0`. Credit to @holgerson97 for the original bump.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [ ] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
