### PR TITLE
fix: merge user-supplied SystemAPIUsers list with generated entries (v11)

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,7 +3,7 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: v4.14.0
-version: 11.0.0-beta.3
+version: 11.0.0-beta.4
 kubeVersion: '>= 1.30.0-0'
 home: https://zitadel.com
 sources:

--- a/charts/zitadel/README.md
+++ b/charts/zitadel/README.md
@@ -2,7 +2,7 @@
 
 # Zitadel
 
-![Version: 11.0.0-beta.1](https://img.shields.io/badge/Version-11.0.0--beta.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.14.0](https://img.shields.io/badge/AppVersion-v4.14.0-informational?style=flat-square)
+![Version: 11.0.0-beta.4](https://img.shields.io/badge/Version-11.0.0--beta.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.14.0](https://img.shields.io/badge/AppVersion-v4.14.0-informational?style=flat-square)
 
 ## A Better Identity and Access Management Solution
 

--- a/charts/zitadel/templates/_helpers.tpl
+++ b/charts/zitadel/templates/_helpers.tpl
@@ -424,7 +424,7 @@ list value would overwrite the chart's generated login-client and admin-client
 entries wholesale, leaving the login pod without credentials and the admin API
 unauthenticated. Folding the list into a map lets the entries merge instead.
 Run this unconditionally (not gated on login.enabled) because admin-client is
-injected independently via adminServiceKey.enabled.
+injected independently via zitadel.adminServiceKey.enabled.
 See https://github.com/zitadel/zitadel-charts/issues/602.
 */}}
 {{- $existing := $config.SystemAPIUsers -}}

--- a/charts/zitadel/templates/_helpers.tpl
+++ b/charts/zitadel/templates/_helpers.tpl
@@ -416,6 +416,25 @@ win, so an operator may override either entry (or add their own).
 */}}
 {{- define "zitadel.mergedConfigmapConfig" -}}
 {{- $config := deepCopy .Values.zitadel.configmapConfig -}}
+{{/*
+Normalize a user-supplied SystemAPIUsers list into a map before merging.
+ZITADEL accepts SystemAPIUsers either as a map (keyed by username) or as a
+list of single-key maps, but Helm's mergeOverwrite only deep-merges maps. A
+list value would overwrite the chart's generated login-client and admin-client
+entries wholesale, leaving the login pod without credentials and the admin API
+unauthenticated. Folding the list into a map lets the entries merge instead.
+Run this unconditionally (not gated on login.enabled) because admin-client is
+injected independently via adminServiceKey.enabled.
+See https://github.com/zitadel/zitadel-charts/issues/602.
+*/}}
+{{- $existing := $config.SystemAPIUsers -}}
+{{- if kindIs "slice" $existing -}}
+{{- $asMap := dict -}}
+{{- range $entry := $existing -}}
+{{- $asMap = mergeOverwrite $asMap $entry -}}
+{{- end -}}
+{{- $_ := set $config "SystemAPIUsers" $asMap -}}
+{{- end -}}
 {{- $sysUsers := dict -}}
 {{- if .Values.login.enabled -}}
 {{- $_ := set $sysUsers "login-client" (dict "Path" "/secrets/login-client/tls.crt" "Memberships" (list (dict "MemberType" "System" "Roles" (list "IAM_LOGIN_CLIENT")))) -}}

--- a/test/smoke/configmap_test.go
+++ b/test/smoke/configmap_test.go
@@ -80,6 +80,28 @@ func TestConfigMapMatrix(t *testing.T) {
 			},
 		},
 		{
+			// Issue #602 follow-up: the list normalization runs unconditionally,
+			// so an admin-key-only install (login disabled, adminServiceKey on)
+			// must still merge the user's list with the generated admin-client
+			// rather than dropping it. login-client must be absent here.
+			name: "user-systemapiusers-list-merges-admin-client-login-disabled",
+			setValues: map[string]string{
+				"login.enabled":                   "false",
+				"zitadel.adminServiceKey.enabled": "true",
+				"zitadel.configmapConfig.SystemAPIUsers[0].superuser.KeyData": validSystemUserKeyData,
+			},
+			zitadel: &assert.ConfigMapAssertion{
+				Data: assert.Matching[map[string]string](gomega.And(
+					gomega.HaveKeyWithValue("zitadel-config-yaml",
+						gomega.ContainSubstring("admin-client")),
+					gomega.HaveKeyWithValue("zitadel-config-yaml",
+						gomega.ContainSubstring("superuser")),
+					gomega.HaveKeyWithValue("zitadel-config-yaml",
+						gomega.Not(gomega.ContainSubstring("login-client"))),
+				)),
+			},
+		},
+		{
 			name: "both-enabled-with-annotations",
 			setValues: map[string]string{
 				"configMap.annotations.owner":      "platform-team",

--- a/test/smoke/configmap_test.go
+++ b/test/smoke/configmap_test.go
@@ -10,6 +10,12 @@ import (
 	"github.com/zitadel/zitadel-charts/test/support"
 )
 
+// validSystemUserKeyData is a base64-encoded RSA public key (PEM). ZITADEL's
+// config loader base64-decodes SystemAPIUsers KeyData, so the value must be
+// valid base64 for the setup job to start. The key itself is only parsed when
+// that system user authenticates, which this test never does.
+const validSystemUserKeyData = "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUFzRjdQWlhZUzV6TWFESHlVK1I3ZQovQlIyRUkzTkZNSWlLSWJrNFk2WXZQNHV1S3huTHlLMy9pM0t0ZUEzOE5Bb21rZTdnNXNkM1VJSDIrdGllTmVtCmlyQUlvUWwwZDZOMTUrYU5VTG9haFpFTjdnVVBjQWJXeW1OeUtYZ1BLMkVYc2lhbzFBcVFVQVdnb2UxYjZ2a08KdVdHSklIRVlhYUlmQjdoVlNQTjh5UTJha2xkYTdIU3kzK2ZpVHVBT3dxRlJqSW51OEROL1hHcC9YYTNIK2kySApCWVUvZ2syT3UvMHFxbDRXY0ZxbVJVQjdKRzZFZEZNSStzUG5iOEkzWTFSazV0Q1Y3TDk0bjhJdVg3MW5EUXdzCjJ6THlpRGFjQkxsWGdyZmx1ZFB1akNMelVtTDIxMlVIeDBtT0UvSm5JdTBzaU54ejEzRXhOcFljc3lkcE1mMFMKWlFJREFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg=="
+
 func TestConfigMapMatrix(t *testing.T) {
 	t.Parallel()
 
@@ -49,6 +55,28 @@ func TestConfigMapMatrix(t *testing.T) {
 						"helm.sh/hook-weight":        "0",
 					}),
 				},
+			},
+		},
+		{
+			// Regression for https://github.com/zitadel/zitadel-charts/issues/602:
+			// a user-supplied SystemAPIUsers list (dash form) must merge with the
+			// chart's generated entries rather than overwriting them. With both
+			// login.enabled and the admin-client key on (the default), all three of
+			// login-client, admin-client and the operator's superuser must survive.
+			name: "user-systemapiusers-list-merges-generated-entries",
+			setValues: map[string]string{
+				"login.enabled": "true",
+				"zitadel.configmapConfig.SystemAPIUsers[0].superuser.KeyData": validSystemUserKeyData,
+			},
+			zitadel: &assert.ConfigMapAssertion{
+				Data: assert.Matching[map[string]string](gomega.And(
+					gomega.HaveKeyWithValue("zitadel-config-yaml",
+						gomega.ContainSubstring("login-client")),
+					gomega.HaveKeyWithValue("zitadel-config-yaml",
+						gomega.ContainSubstring("admin-client")),
+					gomega.HaveKeyWithValue("zitadel-config-yaml",
+						gomega.ContainSubstring("superuser")),
+				)),
 			},
 		},
 		{


### PR DESCRIPTION
### Description

Ports the #602 fix (merged as #604 on the v10/`main` line) to the v11 line on `next`.

The v11 `mergedConfigmapConfig` helper has the same flaw as v10: a user-supplied `SystemAPIUsers` provided as a YAML **list** (the form ZITADEL's own docs use) overwrites the chart's generated entries during `mergeOverwrite` instead of merging with them. On v11 this is worse than on v10 — the chart now injects **both** `login-client` and `admin-client`, so a list-form value breaks login *and* admin API authentication.

The helper now normalizes a list-form `SystemAPIUsers` into a map before merging. Unlike the v10 fix, the normalization runs **unconditionally** (not gated on `login.enabled`), because `admin-client` is injected independently via `zitadel.adminServiceKey.enabled` — so an admin-key-only install with `login.enabled: false` is protected too.

Verified with `helm template` across all four input shapes — `login-client` and `admin-client` both survive in every case:

| Input | login-client | admin-client | superuser |
|---|---|---|---|
| absent | ✅ | ✅ | — |
| `[]` (empty) | ✅ | ✅ | — |
| list | ✅ | ✅ | ✅ |
| map | ✅ | ✅ | ✅ |

A regression case (`user-systemapiusers-list-merges-generated-entries`) was added to `test/smoke/configmap_test.go`, asserting all three entries coexist. Chart bumped to `11.0.0-beta.4` (and the README badge corrected, which was stale at `beta.1`).

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
