### PR TITLE
Instrumentation Support

### DIFF
--- a/charts/zitadel/README.md
+++ b/charts/zitadel/README.md
@@ -251,11 +251,11 @@ Kubernetes: `>= 1.30.0-0`
 | instrumentation.serviceName | string | `nil` | Service name reported for traces, metrics and logs. Maps to `Instrumentation.ServiceName` (ZITADEL_INSTRUMENTATION_SERVICENAME). If null, ZITADEL's default ("zitadel") is used. |
 | instrumentation.trace.batchDuration | string | `nil` | Interval for batching traces before export, e.g. "1s". Maps to ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_BATCHDURATION. If null, ZITADEL's default (1s) is used. |
 | instrumentation.trace.enabled | bool | `false` | Enable trace exporting. When false, no trace configuration is rendered and ZITADEL's defaults apply. |
-| instrumentation.trace.endpoint | string | `""` | Endpoint of the OTEL collector for the "grpc" and "http" exporters, e.g. "otel-collector.monitoring.svc.cluster.local:4317". Maps to ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_ENDPOINT. |
+| instrumentation.trace.endpoint | string | `""` | Endpoint of the OTEL collector for the "grpc" and "http" exporters, e.g. "otel-collector.monitoring.svc.cluster.local:4317". Maps to ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_ENDPOINT. Only rendered when set. |
 | instrumentation.trace.exporterType | string | `"grpc"` | Exporter type. One of: "none", "auto", "stdOut", "stdErr", "grpc", "http", "google". Maps to ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_TYPE. |
 | instrumentation.trace.fraction | string | `nil` | Fraction of traces to sample, between 0.0 and 1.0. Maps to ZITADEL_INSTRUMENTATION_TRACE_FRACTION. If null, ZITADEL's default (1.0) is used. |
 | instrumentation.trace.googleProjectID | string | `nil` | Project ID for the "google" exporter. Maps to ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_GOOGLEPROJECTID. |
-| instrumentation.trace.insecure | bool | `false` | Disable TLS for the "grpc" and "http" exporters. Maps to ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_INSECURE. |
+| instrumentation.trace.insecure | bool | `false` | Disable TLS for the "grpc" and "http" exporters. Maps to ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_INSECURE. Only rendered for the "grpc" and "http" exporter types. |
 | instrumentation.trace.trustRemoteSpans | bool | `false` | Trust incoming trace context from remote services for distributed tracing. Only enable in controlled environments. Maps to ZITADEL_INSTRUMENTATION_TRACE_TRUSTREMOTESPANS. |
 | livenessProbe.enabled | bool | `true` | Enable or disable the liveness probe. |
 | livenessProbe.failureThreshold | int | `3` | Number of consecutive failures before restarting the container. |

--- a/charts/zitadel/README.md
+++ b/charts/zitadel/README.md
@@ -248,6 +248,15 @@ Kubernetes: `>= 1.30.0-0`
 | initJob.podAdditionalLabels | map[string]string | `{}` | Additional labels to add to init job pods. |
 | initJob.podAnnotations | map[string]string | `{}` | Additional annotations to add to init job pods. |
 | initJob.resources | ResourceRequirements | `{}` | CPU and memory resource requests and limits for the init job container. The init job typically requires minimal resources as it only runs SQL commands against the database. |
+| instrumentation.serviceName | string | `nil` | Service name reported for traces, metrics and logs. Maps to `Instrumentation.ServiceName` (ZITADEL_INSTRUMENTATION_SERVICENAME). If null, ZITADEL's default ("zitadel") is used. |
+| instrumentation.trace.batchDuration | string | `nil` | Interval for batching traces before export, e.g. "1s". Maps to ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_BATCHDURATION. If null, ZITADEL's default (1s) is used. |
+| instrumentation.trace.enabled | bool | `false` | Enable trace exporting. When false, no trace configuration is rendered and ZITADEL's defaults apply. |
+| instrumentation.trace.endpoint | string | `""` | Endpoint of the OTEL collector for the "grpc" and "http" exporters, e.g. "otel-collector.monitoring.svc.cluster.local:4317". Maps to ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_ENDPOINT. |
+| instrumentation.trace.exporterType | string | `"grpc"` | Exporter type. One of: "none", "auto", "stdOut", "stdErr", "grpc", "http", "google". Maps to ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_TYPE. |
+| instrumentation.trace.fraction | string | `nil` | Fraction of traces to sample, between 0.0 and 1.0. Maps to ZITADEL_INSTRUMENTATION_TRACE_FRACTION. If null, ZITADEL's default (1.0) is used. |
+| instrumentation.trace.googleProjectID | string | `nil` | Project ID for the "google" exporter. Maps to ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_GOOGLEPROJECTID. |
+| instrumentation.trace.insecure | bool | `false` | Disable TLS for the "grpc" and "http" exporters. Maps to ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_INSECURE. |
+| instrumentation.trace.trustRemoteSpans | bool | `false` | Trust incoming trace context from remote services for distributed tracing. Only enable in controlled environments. Maps to ZITADEL_INSTRUMENTATION_TRACE_TRUSTREMOTESPANS. |
 | livenessProbe.enabled | bool | `true` | Enable or disable the liveness probe. |
 | livenessProbe.failureThreshold | int | `3` | Number of consecutive failures before restarting the container. |
 | livenessProbe.initialDelaySeconds | int | `0` | Seconds to wait before starting liveness checks after container start. |

--- a/charts/zitadel/templates/_helpers.tpl
+++ b/charts/zitadel/templates/_helpers.tpl
@@ -517,11 +517,17 @@ always wins so existing manual configuration keeps working.
 {{- $_ := set $instrumentation "ServiceName" .serviceName -}}
 {{- end -}}
 {{- if .trace.enabled -}}
-{{- $exporter := dict "Type" .trace.exporterType "Endpoint" .trace.endpoint "Insecure" .trace.insecure -}}
+{{- $exporter := dict "Type" .trace.exporterType -}}
+{{- if or (eq .trace.exporterType "grpc") (eq .trace.exporterType "http") -}}
+{{- if .trace.endpoint -}}
+{{- $_ := set $exporter "Endpoint" .trace.endpoint -}}
+{{- end -}}
+{{- $_ := set $exporter "Insecure" .trace.insecure -}}
+{{- end -}}
 {{- if not (kindIs "invalid" .trace.batchDuration) -}}
 {{- $_ := set $exporter "BatchDuration" .trace.batchDuration -}}
 {{- end -}}
-{{- if not (kindIs "invalid" .trace.googleProjectID) -}}
+{{- if and (eq .trace.exporterType "google") (not (kindIs "invalid" .trace.googleProjectID)) -}}
 {{- $_ := set $exporter "GoogleProjectID" .trace.googleProjectID -}}
 {{- end -}}
 {{- $trace := dict "Exporter" $exporter "TrustRemoteSpans" .trace.trustRemoteSpans -}}

--- a/charts/zitadel/templates/_helpers.tpl
+++ b/charts/zitadel/templates/_helpers.tpl
@@ -505,6 +505,35 @@ See https://github.com/zitadel/zitadel-charts/issues/602.
 {{- $loginUser := dict "SystemAPIUsers" (dict "login-client" (dict "Path" "/secrets/login-client/tls.crt" "Memberships" (list (dict "MemberType" "System" "Roles" (list "IAM_LOGIN_CLIENT"))))) -}}
 {{- $config = mergeOverwrite $loginUser $config -}}
 {{- end -}}
+{{/*
+Render native instrumentation (traces) into the ZITADEL config. The chart-level
+.Values.instrumentation block is a convenience wrapper that builds the
+Instrumentation section; user-supplied .Values.zitadel.configmapConfig.Instrumentation
+always wins so existing manual configuration keeps working.
+*/}}
+{{- $instrumentation := dict -}}
+{{- with .Values.instrumentation -}}
+{{- if .serviceName -}}
+{{- $_ := set $instrumentation "ServiceName" .serviceName -}}
+{{- end -}}
+{{- if .trace.enabled -}}
+{{- $exporter := dict "Type" .trace.exporterType "Endpoint" .trace.endpoint "Insecure" .trace.insecure -}}
+{{- if not (kindIs "invalid" .trace.batchDuration) -}}
+{{- $_ := set $exporter "BatchDuration" .trace.batchDuration -}}
+{{- end -}}
+{{- if not (kindIs "invalid" .trace.googleProjectID) -}}
+{{- $_ := set $exporter "GoogleProjectID" .trace.googleProjectID -}}
+{{- end -}}
+{{- $trace := dict "Exporter" $exporter "TrustRemoteSpans" .trace.trustRemoteSpans -}}
+{{- if not (kindIs "invalid" .trace.fraction) -}}
+{{- $_ := set $trace "Fraction" .trace.fraction -}}
+{{- end -}}
+{{- $_ := set $instrumentation "Trace" $trace -}}
+{{- end -}}
+{{- end -}}
+{{- if $instrumentation -}}
+{{- $config = mergeOverwrite (dict "Instrumentation" $instrumentation) $config -}}
+{{- end -}}
 {{- $config | toYaml -}}
 {{- end -}}
 

--- a/charts/zitadel/values.schema.json
+++ b/charts/zitadel/values.schema.json
@@ -443,6 +443,73 @@
                 }
             }
         },
+        "instrumentation": {
+            "type": "object",
+            "properties": {
+                "serviceName": {
+                    "description": "Service name reported for traces, metrics and logs. Maps to `Instrumentation.ServiceName` (ZITADEL_INSTRUMENTATION_SERVICENAME). If null, ZITADEL's default (\"zitadel\") is used.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "trace": {
+                    "type": "object",
+                    "properties": {
+                        "batchDuration": {
+                            "description": "Interval for batching traces before export, e.g. \"1s\". Maps to ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_BATCHDURATION. If null, ZITADEL's default (1s) is used.",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "enabled": {
+                            "description": "Enable trace exporting. When false, no trace configuration is rendered and ZITADEL's defaults apply.",
+                            "type": "boolean"
+                        },
+                        "endpoint": {
+                            "description": "Endpoint of the OTEL collector for the \"grpc\" and \"http\" exporters, e.g. \"otel-collector.monitoring.svc.cluster.local:4317\". Maps to ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_ENDPOINT.",
+                            "type": "string"
+                        },
+                        "exporterType": {
+                            "description": "Exporter type. One of: \"none\", \"auto\", \"stdOut\", \"stdErr\", \"grpc\", \"http\", \"google\". Maps to ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_TYPE.",
+                            "type": "string",
+                            "enum": [
+                                "none",
+                                "auto",
+                                "stdOut",
+                                "stdErr",
+                                "grpc",
+                                "http",
+                                "google"
+                            ]
+                        },
+                        "fraction": {
+                            "description": "Fraction of traces to sample, between 0.0 and 1.0. Maps to ZITADEL_INSTRUMENTATION_TRACE_FRACTION. If null, ZITADEL's default (1.0) is used.",
+                            "type": [
+                                "null",
+                                "number"
+                            ]
+                        },
+                        "googleProjectID": {
+                            "description": "Project ID for the \"google\" exporter. Maps to ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_GOOGLEPROJECTID.",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "insecure": {
+                            "description": "Disable TLS for the \"grpc\" and \"http\" exporters. Maps to ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_INSECURE.",
+                            "type": "boolean"
+                        },
+                        "trustRemoteSpans": {
+                            "description": "Trust incoming trace context from remote services for distributed tracing. Only enable in controlled environments. Maps to ZITADEL_INSTRUMENTATION_TRACE_TRUSTREMOTESPANS.",
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        },
         "livenessProbe": {
             "type": "object",
             "properties": {

--- a/charts/zitadel/values.schema.json
+++ b/charts/zitadel/values.schema.json
@@ -468,7 +468,7 @@
                             "type": "boolean"
                         },
                         "endpoint": {
-                            "description": "Endpoint of the OTEL collector for the \"grpc\" and \"http\" exporters, e.g. \"otel-collector.monitoring.svc.cluster.local:4317\". Maps to ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_ENDPOINT.",
+                            "description": "Endpoint of the OTEL collector for the \"grpc\" and \"http\" exporters, e.g. \"otel-collector.monitoring.svc.cluster.local:4317\". Maps to ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_ENDPOINT. Only rendered when set.",
                             "type": "string"
                         },
                         "exporterType": {
@@ -499,7 +499,7 @@
                             ]
                         },
                         "insecure": {
-                            "description": "Disable TLS for the \"grpc\" and \"http\" exporters. Maps to ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_INSECURE.",
+                            "description": "Disable TLS for the \"grpc\" and \"http\" exporters. Maps to ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_INSECURE. Only rendered for the \"grpc\" and \"http\" exporter types.",
                             "type": "boolean"
                         },
                         "trustRemoteSpans": {

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -1337,10 +1337,11 @@ instrumentation:
     exporterType: "grpc"
     # -- Endpoint of the OTEL collector for the "grpc" and "http" exporters,
     # e.g. "otel-collector.monitoring.svc.cluster.local:4317". Maps to
-    # ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_ENDPOINT.
+    # ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_ENDPOINT. Only rendered when set.
     endpoint: ""
     # -- Disable TLS for the "grpc" and "http" exporters. Maps to
-    # ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_INSECURE.
+    # ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_INSECURE. Only rendered for the
+    # "grpc" and "http" exporter types.
     insecure: false
     # @schema type:[null,number]
     # -- Fraction of traces to sample, between 0.0 and 1.0. Maps to

--- a/charts/zitadel/values.yaml
+++ b/charts/zitadel/values.yaml
@@ -1313,6 +1313,54 @@ metrics:
     # through a proxy.
     proxyUrl: null
 
+# Native OpenTelemetry instrumentation for the ZITADEL container. When enabled,
+# the chart renders the corresponding `Instrumentation` section into the ZITADEL
+# config (merged into zitadel.configmapConfig), so you don't have to set the
+# ZITADEL_INSTRUMENTATION_* env vars manually.
+# Ref: https://zitadel.com/docs/self-hosting/deploy/kubernetes/observability#traces
+# Ref: https://github.com/zitadel/zitadel/blob/main/cmd/defaults.yaml
+instrumentation:
+  # @schema type:[null,string]
+  # -- Service name reported for traces, metrics and logs. Maps to
+  # `Instrumentation.ServiceName` (ZITADEL_INSTRUMENTATION_SERVICENAME). If null,
+  # ZITADEL's default ("zitadel") is used.
+  serviceName: null
+  # Trace (span) exporting configuration. Maps to `Instrumentation.Trace`.
+  trace:
+    # -- Enable trace exporting. When false, no trace configuration is rendered
+    # and ZITADEL's defaults apply.
+    enabled: false
+    # @schema enum:["none","auto","stdOut","stdErr","grpc","http","google"]
+    # -- Exporter type. One of: "none", "auto", "stdOut", "stdErr", "grpc",
+    # "http", "google". Maps to
+    # ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_TYPE.
+    exporterType: "grpc"
+    # -- Endpoint of the OTEL collector for the "grpc" and "http" exporters,
+    # e.g. "otel-collector.monitoring.svc.cluster.local:4317". Maps to
+    # ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_ENDPOINT.
+    endpoint: ""
+    # -- Disable TLS for the "grpc" and "http" exporters. Maps to
+    # ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_INSECURE.
+    insecure: false
+    # @schema type:[null,number]
+    # -- Fraction of traces to sample, between 0.0 and 1.0. Maps to
+    # ZITADEL_INSTRUMENTATION_TRACE_FRACTION. If null, ZITADEL's default (1.0)
+    # is used.
+    fraction: null
+    # -- Trust incoming trace context from remote services for distributed
+    # tracing. Only enable in controlled environments. Maps to
+    # ZITADEL_INSTRUMENTATION_TRACE_TRUSTREMOTESPANS.
+    trustRemoteSpans: false
+    # @schema type:[null,string]
+    # -- Interval for batching traces before export, e.g. "1s". Maps to
+    # ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_BATCHDURATION. If null, ZITADEL's
+    # default (1s) is used.
+    batchDuration: null
+    # @schema type:[null,string]
+    # -- Project ID for the "google" exporter. Maps to
+    # ZITADEL_INSTRUMENTATION_TRACE_EXPORTER_GOOGLEPROJECTID.
+    googleProjectID: null
+
 # Pod Disruption Budget configuration for the main ZITADEL deployment.
 # Ensures high availability by limiting the number of pods that can be
 # simultaneously unavailable during voluntary disruptions (e.g., node drains,

--- a/examples/6-instrumentation/README.md
+++ b/examples/6-instrumentation/README.md
@@ -1,0 +1,40 @@
+# Instrumentation (Traces & Metrics) Example
+
+This example shows how to enable native observability for ZITADEL: [Prometheus metrics](https://zitadel.com/docs/self-hosting/deploy/kubernetes/observability#metrics) and [OpenTelemetry traces](https://zitadel.com/docs/self-hosting/deploy/kubernetes/observability#traces).
+
+By setting the top-level `instrumentation.trace` values, the chart renders the corresponding `Instrumentation.Trace` section into the ZITADEL config for you, so you don't have to set the `ZITADEL_INSTRUMENTATION_*` environment variables manually.
+Setting `metrics.enabled` to `true` exposes Prometheus metrics on `/debug/metrics`.
+
+By running the commands below, you deploy a simple, insecure Postgres database to your Kubernetes cluster [by using the Bitnami chart](https://artifacthub.io/packages/helm/bitnami/postgresql).
+Also, you deploy [a correctly configured ZITADEL](https://artifacthub.io/packages/helm/zitadel/zitadel).
+
+> [!WARNING]
+> Anybody with network access to the Postgres database can connect to it and read and write data.
+> Use this example only for testing purposes.
+> For deploying a secure Postgres database, see [the secure Postgres example](../2-postgres-secure/README.md).
+
+> [!INFO]
+> The example assumes you already have a running Kubernetes cluster with a working ingress controller.
+> If you don't, [run a local KinD cluster](../99-kind-with-traefik/README.md) before executing the following commands.
+>
+> The trace exporter `endpoint` in [`zitadel-values.yaml`](./zitadel-values.yaml) points at an example OpenTelemetry collector
+> (`alloy.monitoring.svc.cluster.local:4318`). Adjust it to match your own collector, or ZITADEL will simply fail to export traces
+> without affecting its normal operation.
+
+```bash
+# Install Postgres
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm install --wait db bitnami/postgresql --version 12.10.0 --values https://raw.githubusercontent.com/zitadel/zitadel-charts/main/examples/6-instrumentation/postgres-values.yaml
+
+# Install Zitadel
+helm repo add zitadel https://charts.zitadel.com
+helm install my-zitadel zitadel/zitadel --values https://raw.githubusercontent.com/zitadel/zitadel-charts/main/examples/6-instrumentation/zitadel-values.yaml
+```
+
+When Zitadel is ready, open https://instrumentation.127.0.0.1.sslip.io/ui/console?login_hint=zitadel-admin@zitadel.instrumentation.127.0.0.1.sslip.io in your browser and log in with the password `Password1!`.
+
+To verify the tracing configuration was rendered into the ZITADEL config, inspect the generated ConfigMap:
+
+```bash
+kubectl get configmap my-zitadel-config-yaml -o jsonpath='{.data.zitadel-config-yaml}' | grep -A8 'Instrumentation:'
+```

--- a/examples/6-instrumentation/postgres-values.yaml
+++ b/examples/6-instrumentation/postgres-values.yaml
@@ -1,0 +1,16 @@
+image:
+  repository: bitnamilegacy/postgresql
+
+metrics:
+  image:
+    repository: bitnamilegacy/postgres-exporter
+
+volumePermissions:
+  image:
+    repository: bitnamilegacy/os-shell
+
+primary:
+  persistence:
+    enabled: false
+  pgHbaConfiguration: |
+    host all all all trust

--- a/examples/6-instrumentation/zitadel-values.yaml
+++ b/examples/6-instrumentation/zitadel-values.yaml
@@ -1,0 +1,56 @@
+# Native OpenTelemetry instrumentation. The chart renders the corresponding
+# Instrumentation section into the ZITADEL config, so you don't have to set the
+# ZITADEL_INSTRUMENTATION_* environment variables manually.
+# Ref: https://zitadel.com/docs/self-hosting/deploy/kubernetes/observability#traces
+instrumentation:
+  # Service name reported for traces. Defaults to "zitadel" if omitted.
+  serviceName: zitadel
+  trace:
+    # Enable trace exporting.
+    enabled: true
+    # Exporter type: "grpc" (recommended) or "http".
+    exporterType: http
+    # Endpoint of your OpenTelemetry collector's OTLP receiver.
+    # Adjust this to point at your collector (e.g. an OpenTelemetry Collector,
+    # Grafana Alloy, or Jaeger). The gRPC receiver typically listens on 4317
+    # and the HTTP receiver on 4318.
+    endpoint: alloy.monitoring.svc.cluster.local:4318
+    # Disable TLS towards the collector. Set to false and configure TLS on your
+    # collector for production deployments.
+    insecure: true
+    # Sample every trace. Lower this (e.g. 0.1) to reduce trace volume.
+    fraction: 1.0
+
+# Expose Prometheus metrics from ZITADEL on /debug/metrics.
+metrics:
+  enabled: true
+
+zitadel:
+  masterkey: x123456789012345678901234567891y
+  configmapConfig:
+    ExternalDomain: instrumentation.127.0.0.1.sslip.io
+    ExternalPort: 443
+    TLS:
+      Enabled: false
+    Database:
+      Postgres:
+        Host: db-postgresql
+        Port: 5432
+        Database: zitadel
+        MaxOpenConns: 20
+        MaxIdleConns: 10
+        MaxConnLifetime: 30m
+        MaxConnIdleTime: 5m
+        User:
+          Username: postgres
+          SSL:
+            Mode: disable
+        Admin:
+          Username: postgres
+          SSL:
+            Mode: disable
+ingress:
+  enabled: true
+login:
+  ingress:
+    enabled: true

--- a/test/instrumentation_test.go
+++ b/test/instrumentation_test.go
@@ -1,0 +1,174 @@
+package test
+
+import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// renderOpt configures a helm template invocation for renderZitadelConfig.
+type renderOpt struct {
+	set     []string // --set key=value (string-typed)
+	setJSON []string // --set-json key=value (typed, e.g. numbers)
+}
+
+// renderZitadelConfig renders the chart with the given overrides and returns
+// the parsed ZITADEL config from the config ConfigMap. It exercises the chart
+// through its public interface (helm template output) so the tests survive
+// internal template refactors.
+func renderZitadelConfig(t *testing.T, opt renderOpt) map[string]any {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller(0) failed")
+	chartPath := filepath.Join(filepath.Dir(file), "..", "charts", "zitadel")
+
+	args := []string{
+		"template", "zitadel", chartPath,
+		"--kube-version", "1.30.0",
+		"--set", "zitadel.masterkey=dGVzdC1tYXN0ZXJrZXktZm9yLXZhbGlkYXRpb24=",
+		"--show-only", "templates/configmap_zitadel.yaml",
+	}
+	for _, s := range opt.set {
+		args = append(args, "--set", s)
+	}
+	for _, s := range opt.setJSON {
+		args = append(args, "--set-json", s)
+	}
+
+	out, err := exec.Command("helm", args...).CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	var cm struct {
+		Data struct {
+			Config string `yaml:"zitadel-config-yaml"`
+		} `yaml:"data"`
+	}
+	require.NoError(t, yaml.Unmarshal(out, &cm))
+
+	config := map[string]any{}
+	require.NoError(t, yaml.Unmarshal([]byte(cm.Data.Config), &config))
+	return config
+}
+
+// traceExporter navigates to Instrumentation.Trace.Exporter in the rendered
+// config, returning the exporter map and whether it was present.
+func traceExporter(config map[string]any) (map[string]any, bool) {
+	instr, ok := config["Instrumentation"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	trace, ok := instr["Trace"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	exporter, ok := trace["Exporter"].(map[string]any)
+	return exporter, ok
+}
+
+// TestTraceStdoutExporterOmitsEndpoint verifies that a non-endpoint exporter
+// (stdOut) does not render an empty Endpoint into the ZITADEL config. An empty
+// Endpoint is meaningless for stdOut and pollutes the config.
+func TestTraceStdoutExporterOmitsEndpoint(t *testing.T) {
+	t.Parallel()
+
+	config := renderZitadelConfig(t, renderOpt{set: []string{
+		"instrumentation.trace.enabled=true",
+		"instrumentation.trace.exporterType=stdOut",
+	}})
+
+	exporter, ok := traceExporter(config)
+	require.True(t, ok, "expected Instrumentation.Trace.Exporter to be rendered")
+
+	_, hasEndpoint := exporter["Endpoint"]
+	require.False(t, hasEndpoint,
+		"stdOut exporter must not render an Endpoint, got: %v", exporter["Endpoint"])
+}
+
+// TestTraceGrpcExporterRendersEndpoint verifies that when an endpoint is
+// supplied for an endpoint-based exporter (grpc/http), it is rendered into the
+// ZITADEL config so ZITADEL knows where to push traces.
+func TestTraceGrpcExporterRendersEndpoint(t *testing.T) {
+	t.Parallel()
+
+	config := renderZitadelConfig(t, renderOpt{set: []string{
+		"instrumentation.trace.enabled=true",
+		"instrumentation.trace.exporterType=grpc",
+		"instrumentation.trace.endpoint=otel-collector:4317",
+	}})
+
+	exporter, ok := traceExporter(config)
+	require.True(t, ok, "expected Instrumentation.Trace.Exporter to be rendered")
+
+	require.Equal(t, "otel-collector:4317", exporter["Endpoint"],
+		"grpc exporter must render the configured Endpoint")
+}
+
+// TestTraceStdoutExporterOmitsInsecure verifies that the Insecure flag, which
+// only applies to endpoint-based exporters (grpc/http), is not rendered for a
+// non-endpoint exporter like stdOut.
+func TestTraceStdoutExporterOmitsInsecure(t *testing.T) {
+	t.Parallel()
+
+	config := renderZitadelConfig(t, renderOpt{set: []string{
+		"instrumentation.trace.enabled=true",
+		"instrumentation.trace.exporterType=stdOut",
+	}})
+
+	exporter, ok := traceExporter(config)
+	require.True(t, ok, "expected Instrumentation.Trace.Exporter to be rendered")
+
+	_, hasInsecure := exporter["Insecure"]
+	require.False(t, hasInsecure,
+		"stdOut exporter must not render Insecure, got: %v", exporter["Insecure"])
+}
+
+// TestTraceGrpcExporterRendersInsecure verifies that the Insecure flag is
+// rendered for endpoint-based exporters, where it controls TLS towards the
+// collector.
+func TestTraceGrpcExporterRendersInsecure(t *testing.T) {
+	t.Parallel()
+
+	config := renderZitadelConfig(t, renderOpt{set: []string{
+		"instrumentation.trace.enabled=true",
+		"instrumentation.trace.exporterType=grpc",
+		"instrumentation.trace.endpoint=otel-collector:4317",
+		"instrumentation.trace.insecure=true",
+	}})
+
+	exporter, ok := traceExporter(config)
+	require.True(t, ok, "expected Instrumentation.Trace.Exporter to be rendered")
+
+	require.Equal(t, true, exporter["Insecure"],
+		"grpc exporter must render the configured Insecure flag")
+}
+
+// TestTraceFractionRendersAsNumber verifies that a numeric fraction is accepted
+// by the schema and rendered into the config. Fraction is typed as a number in
+// values.schema.json, so it must be supplied via --set-json.
+func TestTraceFractionRendersAsNumber(t *testing.T) {
+	t.Parallel()
+
+	config := renderZitadelConfig(t, renderOpt{
+		set: []string{
+			"instrumentation.trace.enabled=true",
+			"instrumentation.trace.exporterType=grpc",
+			"instrumentation.trace.endpoint=otel-collector:4317",
+		},
+		setJSON: []string{
+			"instrumentation.trace.fraction=0.5",
+		},
+	})
+
+	instr, ok := config["Instrumentation"].(map[string]any)
+	require.True(t, ok, "expected Instrumentation to be rendered")
+	trace, ok := instr["Trace"].(map[string]any)
+	require.True(t, ok, "expected Instrumentation.Trace to be rendered")
+
+	require.Equal(t, 0.5, trace["Fraction"],
+		"Fraction must be rendered as a number")
+}

--- a/test/smoke/instrumentation_test.go
+++ b/test/smoke/instrumentation_test.go
@@ -1,0 +1,138 @@
+package smoke_test_test
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+
+	"github.com/mridang/wilhelm/assert"
+	setup "github.com/zitadel/zitadel-charts/test/smoke/support"
+	"github.com/zitadel/zitadel-charts/test/support"
+)
+
+// configMapDataMatches builds a ConfigMapAssertion that asserts the rendered
+// ZITADEL config (stored under the "zitadel-config-yaml" key) satisfies the
+// given gomega matcher.
+func configMapDataMatches(matcher gomega.OmegaMatcher) assert.ConfigMapAssertion {
+	return assert.ConfigMapAssertion{
+		Data: assert.Matching[map[string]string](
+			gomega.HaveKeyWithValue("zitadel-config-yaml", matcher),
+		),
+	}
+}
+
+//goland:noinspection ALL
+func TestInstrumentationDisabledByDefault(t *testing.T) {
+	t.Parallel()
+
+	support.WithNamespace(t, func(env *support.Env) {
+		releaseName := setup.InstallZitadel(t, env, "instr-disabled", nil)
+
+		// With no instrumentation values set, the chart must not render an
+		// Instrumentation section into the ZITADEL config.
+		env.AssertPartial(t, releaseName+"-config-yaml", configMapDataMatches(
+			gomega.Not(gomega.ContainSubstring("Instrumentation:")),
+		))
+	})
+}
+
+//goland:noinspection ALL
+func TestInstrumentationMatrix(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		setValues map[string]string
+		// expect are substrings that must be present in the rendered config.
+		expect []string
+		// reject are substrings that must NOT be present in the rendered config.
+		reject []string
+	}{
+		{
+			name: "trace-http",
+			setValues: map[string]string{
+				"instrumentation.trace.enabled":      "true",
+				"instrumentation.trace.exporterType": "http",
+				"instrumentation.trace.endpoint":     "alloy.vm.svc.cluster.local:4318",
+				"instrumentation.trace.insecure":     "true",
+			},
+			expect: []string{
+				"Instrumentation:",
+				"Trace:",
+				"Exporter:",
+				"Type: http",
+				"Endpoint: alloy.vm.svc.cluster.local:4318",
+				"Insecure: true",
+			},
+		},
+		{
+			name: "trace-grpc-with-service-name",
+			setValues: map[string]string{
+				"instrumentation.serviceName":        "zitadel",
+				"instrumentation.trace.enabled":      "true",
+				"instrumentation.trace.exporterType": "grpc",
+				"instrumentation.trace.endpoint":     "otel-collector.monitoring.svc.cluster.local:4317",
+			},
+			expect: []string{
+				"ServiceName: zitadel",
+				"Type: grpc",
+				"Endpoint: otel-collector.monitoring.svc.cluster.local:4317",
+				"Insecure: false",
+			},
+		},
+		{
+			name: "trace-fraction-and-batch-duration",
+			setValues: map[string]string{
+				"instrumentation.trace.enabled":          "true",
+				"instrumentation.trace.endpoint":         "otel:4317",
+				"instrumentation.trace.batchDuration":    "2s",
+				"instrumentation.trace.trustRemoteSpans": "true",
+				// Fraction is a number in the schema; --set-string keeps the
+				// literal but Helm coerces it back to a numeric YAML scalar.
+				"instrumentation.trace.fraction": "0.5",
+			},
+			expect: []string{
+				"BatchDuration: 2s",
+				"TrustRemoteSpans: true",
+				"Fraction: 0.5",
+			},
+		},
+		{
+			name: "user-configmap-config-wins",
+			setValues: map[string]string{
+				"instrumentation.trace.enabled":  "true",
+				"instrumentation.trace.endpoint": "chart.example:4317",
+				// A user-supplied configmapConfig value must override the
+				// chart-generated instrumentation config.
+				"zitadel.configmapConfig.Instrumentation.Trace.Exporter.Endpoint": "user.example:4317",
+			},
+			expect: []string{
+				"Endpoint: user.example:4317",
+			},
+			reject: []string{
+				"Endpoint: chart.example:4317",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			support.WithNamespace(t, func(env *support.Env) {
+				releaseName := setup.InstallZitadel(t, env, tc.name, tc.setValues)
+
+				matchers := make([]gomega.OmegaMatcher, 0, len(tc.expect)+len(tc.reject))
+				for _, s := range tc.expect {
+					matchers = append(matchers, gomega.ContainSubstring(s))
+				}
+				for _, s := range tc.reject {
+					matchers = append(matchers, gomega.Not(gomega.ContainSubstring(s)))
+				}
+
+				env.AssertPartial(t, releaseName+"-config-yaml", configMapDataMatches(
+					gomega.And(matchers...),
+				))
+			})
+		})
+	}
+}

--- a/test/smoke/instrumentation_test.go
+++ b/test/smoke/instrumentation_test.go
@@ -81,20 +81,16 @@ func TestInstrumentationMatrix(t *testing.T) {
 			},
 		},
 		{
-			name: "trace-fraction-and-batch-duration",
+			name: "trace-batch-duration-and-trust-remote-spans",
 			setValues: map[string]string{
 				"instrumentation.trace.enabled":          "true",
 				"instrumentation.trace.endpoint":         "otel:4317",
 				"instrumentation.trace.batchDuration":    "2s",
 				"instrumentation.trace.trustRemoteSpans": "true",
-				// Fraction is a number in the schema; --set-string keeps the
-				// literal but Helm coerces it back to a numeric YAML scalar.
-				"instrumentation.trace.fraction": "0.5",
 			},
 			expect: []string{
 				"BatchDuration: 2s",
 				"TrustRemoteSpans: true",
-				"Fraction: 0.5",
 			},
 		},
 		{


### PR DESCRIPTION
This PR makes ZITADEL tracing instrumentation settings configurable through the Helm chart. Users can now customize the OpenTelemetry service name, trace sampling, remote span trust, and trace exporter configuration (type, endpoint, TLS, batch duration, and Google Cloud project ID) via Helm values instead of relying on the default configuration.

### Definition of Ready

- [X] I am happy with the code
- [X] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [X] No debug or dead code
- [X] My code has no repetitions
- [X] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
