### PR TITLE
Fix the login Service Key checksum annotation

### DIFF
--- a/charts/zitadel/Chart.yaml
+++ b/charts/zitadel/Chart.yaml
@@ -3,8 +3,8 @@ name: zitadel
 description: A Helm chart for ZITADEL
 type: application
 appVersion: v4.15.3
-version: 10.0.4
-kubeVersion: '>= 1.30.0-0'
+version: 10.0.5
+kubeVersion: ">= 1.30.0-0"
 home: https://zitadel.com
 sources:
   - https://github.com/zitadel/zitadel

--- a/charts/zitadel/README.md
+++ b/charts/zitadel/README.md
@@ -2,7 +2,7 @@
 
 # Zitadel
 
-![Version: 10.0.4](https://img.shields.io/badge/Version-10.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.15.3](https://img.shields.io/badge/AppVersion-v4.15.3-informational?style=flat-square)
+![Version: 10.0.5](https://img.shields.io/badge/Version-10.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v4.15.3](https://img.shields.io/badge/AppVersion-v4.15.3-informational?style=flat-square)
 
 ## A Better Identity and Access Management Solution
 

--- a/charts/zitadel/templates/deployment_login.yaml
+++ b/charts/zitadel/templates/deployment_login.yaml
@@ -27,7 +27,9 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap_login.yaml") . | sha256sum }}
+        {{- if and .Values.login.enabled (not .Values.login.loginServiceKeySecretName) }}
         checksum/secret-login-service-key: {{ include (print $.Template.BasePath "/secret_login-service-key.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.login.metrics.enabled }}
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"

--- a/charts/zitadel/templates/deployment_zitadel.yaml
+++ b/charts/zitadel/templates/deployment_zitadel.yaml
@@ -28,7 +28,7 @@ spec:
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap_zitadel.yaml") . | sha256sum }}
         checksum/secret-db-ssl-ca-crt: {{ include (print $.Template.BasePath "/secret_db-ssl-ca-crt.yaml") . | sha256sum }}
         checksum/secret-zitadel-secrets: {{ include (print $.Template.BasePath "/secret_zitadel-secrets.yaml") . | sha256sum }}
-        {{- if .Values.login.enabled }}
+        {{- if and .Values.login.enabled (not .Values.login.loginServiceKeySecretName) }}
         checksum/secret-login-service-key: {{ include (print $.Template.BasePath "/secret_login-service-key.yaml") . | sha256sum }}
         {{- end }}
         {{- if .Values.metrics.enabled }}

--- a/test/smoke/autoscaling_test.go
+++ b/test/smoke/autoscaling_test.go
@@ -247,7 +247,6 @@ func TestAutoscalingMatrix(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			support.WithNamespace(t, func(env *support.Env) {

--- a/test/smoke/configmap_test.go
+++ b/test/smoke/configmap_test.go
@@ -144,7 +144,6 @@ func TestConfigMapMatrix(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			support.WithNamespace(t, func(env *support.Env) {

--- a/test/smoke/deployment_test.go
+++ b/test/smoke/deployment_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/mridang/wilhelm/assert"
 	setup "github.com/zitadel/zitadel-charts/test/smoke/support"
@@ -17,10 +18,11 @@ func TestDeploymentMatrix(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name      string
-		setValues map[string]string
-		zitadel   *assert.DeploymentAssertion
-		login     *assert.DeploymentAssertion
+		name       string
+		setValues  map[string]string
+		preInstall func(t *testing.T, env *support.Env)
+		zitadel    *assert.DeploymentAssertion
+		login      *assert.DeploymentAssertion
 	}{
 		{
 			name: "defaults",
@@ -210,6 +212,85 @@ func TestDeploymentMatrix(t *testing.T) {
 			},
 		},
 		{
+			// Helm manages the secret, so the checksum annotation must be present on both deployments.
+			name: "login-service-key-checksum-present-when-helm-managed",
+			setValues: map[string]string{
+				"login.enabled": "true",
+			},
+			zitadel: &assert.DeploymentAssertion{
+				Spec: assert.DeploymentSpecAssertion{
+					Template: assert.PodTemplateSpecAssertion{
+						ObjectMeta: assert.ObjectMetaAssertion{
+							Annotations: assert.Matching[map[string]string](
+								gomega.HaveKey("checksum/secret-login-service-key"),
+							),
+						},
+					},
+				},
+			},
+			login: &assert.DeploymentAssertion{
+				Spec: assert.DeploymentSpecAssertion{
+					Template: assert.PodTemplateSpecAssertion{
+						ObjectMeta: assert.ObjectMetaAssertion{
+							Annotations: assert.Matching[map[string]string](
+								gomega.HaveKey("checksum/secret-login-service-key"),
+							),
+						},
+					},
+				},
+			},
+		},
+		{
+			// External secret (e.g. cert-manager): Helm does not own the secret,
+			// so the checksum annotation must NOT appear on either deployment.
+			name: "login-service-key-checksum-absent-when-external-secret",
+			setValues: map[string]string{
+				"login.enabled":                   "true",
+				"login.loginServiceKeySecretName": "my-external-secret",
+			},
+			preInstall: func(t *testing.T, env *support.Env) {
+				t.Helper()
+				certPEM, keyPEM := generateSelfSignedTLS(t)
+				_, err := env.Client.CoreV1().Secrets(env.Namespace).Create(
+					env.Ctx,
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Name: "my-external-secret"},
+						Type:       corev1.SecretTypeTLS,
+						Data: map[string][]byte{
+							"tls.crt": certPEM,
+							"tls.key": keyPEM,
+						},
+					},
+					metav1.CreateOptions{},
+				)
+				if err != nil {
+					t.Fatalf("failed to create external secret: %v", err)
+				}
+			},
+			zitadel: &assert.DeploymentAssertion{
+				Spec: assert.DeploymentSpecAssertion{
+					Template: assert.PodTemplateSpecAssertion{
+						ObjectMeta: assert.ObjectMetaAssertion{
+							Annotations: assert.Matching[map[string]string](
+								gomega.Not(gomega.HaveKey("checksum/secret-login-service-key")),
+							),
+						},
+					},
+				},
+			},
+			login: &assert.DeploymentAssertion{
+				Spec: assert.DeploymentSpecAssertion{
+					Template: assert.PodTemplateSpecAssertion{
+						ObjectMeta: assert.ObjectMetaAssertion{
+							Annotations: assert.Matching[map[string]string](
+								gomega.Not(gomega.HaveKey("checksum/secret-login-service-key")),
+							),
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "component-overrides",
 			setValues: map[string]string{
 				"login.enabled":         "true",
@@ -317,10 +398,12 @@ func TestDeploymentMatrix(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			support.WithNamespace(t, func(env *support.Env) {
+				if tc.preInstall != nil {
+					tc.preInstall(t, env)
+				}
 				releaseName := setup.InstallZitadel(t, env, tc.name, tc.setValues)
 
 				if tc.zitadel != nil {

--- a/test/smoke/gateway_test.go
+++ b/test/smoke/gateway_test.go
@@ -240,7 +240,6 @@ func TestGatewayHTTPRouteMatrix(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			support.WithNamespace(t, func(env *support.Env) {
@@ -345,7 +344,6 @@ func TestGatewayGRPCRouteMatrix(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			support.WithNamespace(t, func(env *support.Env) {

--- a/test/smoke/ingress_test.go
+++ b/test/smoke/ingress_test.go
@@ -90,7 +90,6 @@ func TestIngressMatrix(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			support.WithNamespace(t, func(env *support.Env) {

--- a/test/smoke/pdb_test.go
+++ b/test/smoke/pdb_test.go
@@ -199,7 +199,6 @@ func TestPodDisruptionBudgetMatrix(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			support.WithNamespace(t, func(env *support.Env) {

--- a/test/smoke/rbac_test.go
+++ b/test/smoke/rbac_test.go
@@ -41,7 +41,6 @@ func TestRBACLabels(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			support.WithNamespace(t, func(env *support.Env) {

--- a/test/smoke/secrets_test.go
+++ b/test/smoke/secrets_test.go
@@ -249,7 +249,6 @@ func TestSecretsMatrix(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			support.WithNamespace(t, func(env *support.Env) {

--- a/test/smoke/servacc_test.go
+++ b/test/smoke/servacc_test.go
@@ -126,7 +126,6 @@ func TestServiceAccountMatrix(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			support.WithNamespace(t, func(env *support.Env) {

--- a/test/smoke/servicemonitor_test.go
+++ b/test/smoke/servicemonitor_test.go
@@ -205,7 +205,6 @@ func TestServiceMonitorMatrix(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			support.WithNamespace(t, func(env *support.Env) {

--- a/test/smoke/services_test.go
+++ b/test/smoke/services_test.go
@@ -187,7 +187,6 @@ func TestServiceMatrix(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			support.WithNamespace(t, func(env *support.Env) {


### PR DESCRIPTION
The checksum should only be calculated if we have the helm chart create the secret. If we define the secretName the helm Chart isn't managing the secret and therefore should not annotate the workloads. E.g. When using cert-manager.

### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] If possible, [the test configuration](https://github.com/zitadel/zitadel-charts/blob/main/charts/zitadel/test/installation/config_test.go) is adjusted so acceptance tests cover my changes
